### PR TITLE
Ensure Ctrl+C runs full shutdown sequence

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -2356,9 +2356,7 @@ class MainWindow(QMainWindow):
         if not _SIGINT_TRIGGERED:
             return
         _SIGINT_TRIGGERED = False
-        app = QApplication.instance()
-        if app:
-            app.quit()
+        self._begin_exit_sequence()
 
     def _begin_exit_sequence(self):
         if self._exit_in_progress:


### PR DESCRIPTION
## Summary
- route SIGINT polling to begin the full exit sequence instead of quitting immediately
- ensure terminal Ctrl+C triggers the same docker cleanup path used by the GUI close button

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e123590ce48331981145c9d7a7c5b0