### PR TITLE
Fix web server response flushing for web dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Instead of starting all docker container and run one terminator for logging you 
 - User scripts live in `./scripts/`; edit locally, then use the Scripts toggle to run/stop them inside `mobipick_cmd`.
 - The Sim/Tables/RViz/RQt toggles send output to their named tabs; use `Update Status` if you need to resync button state with running containers.
 - To serve the same controls in a browser start the GUI with `python gui.py --web`. The terminal prints the URL (e.g. `http://127.0.0.1:8080`); open it to access the web dashboard. Use the layout selector to arrange embedded process logs (one, two, or three columns), toggle individual tabs on/off, or pop any tab into a separate window while the backend continues to manage the ROS processes.
+- When debugging browser connectivity issues run `python gui.py --web --debug`. This enables verbose logging in dark green on the terminal and writes a detailed session log to `mobipick_debug.log` for later inspection.
 
 ## Shutdown
 To stop everything call `docker compose down`.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Instead of starting all docker container and run one terminator for logging you 
 - Always start Roscore first—other toggles do it automatically but the master must stay up for everything else.
 - User scripts live in `./scripts/`; edit locally, then use the Scripts toggle to run/stop them inside `mobipick_cmd`.
 - The Sim/Tables/RViz/RQt toggles send output to their named tabs; use `Update Status` if you need to resync button state with running containers.
+- To serve the same controls in a browser start the GUI with `python gui.py --web`. The terminal prints the URL (e.g. `http://127.0.0.1:8080`); open it to access the web dashboard. Use the layout selector to arrange embedded process logs (one, two, or three columns), toggle individual tabs on/off, or pop any tab into a separate window while the backend continues to manage the ROS processes.
 
 ## Shutdown
 To stop everything call `docker compose down`.

--- a/gui.py
+++ b/gui.py
@@ -5,9 +5,17 @@ import argparse
 import signal
 import sys
 
+from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QApplication
 
-from mobipick_gui import MainWindow, trigger_sigint
+from mobipick_gui import (
+    MainWindow,
+    WebBridge,
+    WebController,
+    WebUiServer,
+    find_free_port,
+    trigger_sigint,
+)
 
 
 def main() -> int:
@@ -22,20 +30,61 @@ def main() -> int:
         choices=[1, 2, 3],
         help='Verbosity level (1=min, 3=max). If no value provided defaults to 3.'
     )
+    parser.add_argument(
+        '--web',
+        action='store_true',
+        help='Serve the GUI over HTTP instead of showing the native Qt window.',
+    )
+    parser.add_argument(
+        '--web-port',
+        type=int,
+        default=0,
+        help='Port for the web UI (0 selects an available port automatically).',
+    )
+    parser.add_argument(
+        '--web-host',
+        type=str,
+        default='127.0.0.1',
+        help='Host interface for the web UI.',
+    )
 
     parsed_args, qt_args = parser.parse_known_args()
     verbosity = parsed_args.verbosity or 1
 
     app = QApplication([sys.argv[0]] + qt_args)
-    window = MainWindow(verbosity=verbosity)
-    window.show()
+    bridge: WebBridge | None = None
+    server: WebUiServer | None = None
+
+    if parsed_args.web:
+        bridge = WebBridge()
+        window = MainWindow(verbosity=verbosity, web_bridge=bridge)
+        window.setAttribute(Qt.WA_DontShowOnScreen, True)
+        controller = WebController(window, bridge)
+        host = parsed_args.web_host or '127.0.0.1'
+        port = parsed_args.web_port if parsed_args.web_port and parsed_args.web_port > 0 else find_free_port()
+        server = WebUiServer(bridge, controller, host=host, port=port)
+        server.start()
+        address = server.address
+        if address:
+            host, port = address
+            print(f'Web UI available at http://{host}:{port}', flush=True)
+        else:
+            print('Failed to start web server', file=sys.stderr)
+    else:
+        window = MainWindow(verbosity=verbosity)
+        window.show()
 
     def _handle_sigint(_sig, _frame):
         trigger_sigint()
 
     signal.signal(signal.SIGINT, _handle_sigint)
-
-    return app.exec_()
+    try:
+        return app.exec_()
+    finally:
+        if bridge is not None:
+            bridge.shutdown()
+        if server is not None:
+            server.stop()
 
 
 if __name__ == '__main__':

--- a/gui.py
+++ b/gui.py
@@ -13,9 +13,14 @@ from mobipick_gui import (
     WebBridge,
     WebController,
     WebUiServer,
+    configure_logging,
     find_free_port,
+    get_logger,
     trigger_sigint,
 )
+
+
+logger = get_logger(__name__)
 
 
 def main() -> int:
@@ -47,43 +52,63 @@ def main() -> int:
         default='127.0.0.1',
         help='Host interface for the web UI.',
     )
+    parser.add_argument(
+        '--debug',
+        action='store_true',
+        help='Enable verbose debug logging and write to mobipick_debug.log.',
+    )
 
     parsed_args, qt_args = parser.parse_known_args()
     verbosity = parsed_args.verbosity or 1
+
+    log_path = configure_logging(parsed_args.debug)
+    if parsed_args.debug and log_path is not None:
+        print(f'Debug log file: {log_path}', flush=True)
+
+    logger.debug('Parsed CLI arguments: %s', parsed_args)
 
     app = QApplication([sys.argv[0]] + qt_args)
     bridge: WebBridge | None = None
     server: WebUiServer | None = None
 
     if parsed_args.web:
+        logger.debug('Initializing web mode with hidden Qt window')
         bridge = WebBridge()
         window = MainWindow(verbosity=verbosity, web_bridge=bridge)
         window.setAttribute(Qt.WA_DontShowOnScreen, True)
         controller = WebController(window, bridge)
         host = parsed_args.web_host or '127.0.0.1'
         port = parsed_args.web_port if parsed_args.web_port and parsed_args.web_port > 0 else find_free_port()
+        logger.debug('Starting WebUiServer on %s:%s', host, port)
         server = WebUiServer(bridge, controller, host=host, port=port)
         server.start()
         address = server.address
         if address:
             host, port = address
             print(f'Web UI available at http://{host}:{port}', flush=True)
+            logger.info('Web UI available at http://%s:%s', host, port)
         else:
             print('Failed to start web server', file=sys.stderr)
+            logger.error('Failed to determine web server address after start')
     else:
+        logger.debug('Starting native Qt GUI mode')
         window = MainWindow(verbosity=verbosity)
         window.show()
 
     def _handle_sigint(_sig, _frame):
+        logger.debug('SIGINT received; triggering shutdown')
         trigger_sigint()
 
     signal.signal(signal.SIGINT, _handle_sigint)
     try:
+        logger.debug('Entering Qt event loop')
         return app.exec_()
     finally:
         if bridge is not None:
+            logger.debug('Shutting down web bridge')
             bridge.shutdown()
         if server is not None:
+            logger.debug('Stopping web server')
             server.stop()
 
 

--- a/mobipick_gui/__init__.py
+++ b/mobipick_gui/__init__.py
@@ -1,5 +1,15 @@
 """Mobipick Labs GUI package."""
 
 from .main_window import MainWindow, trigger_sigint
+from .web_bridge import WebBridge
+from .web_controller import WebController
+from .web_server import WebUiServer, find_free_port
 
-__all__ = ["MainWindow", "trigger_sigint"]
+__all__ = [
+    "MainWindow",
+    "WebBridge",
+    "WebController",
+    "WebUiServer",
+    "find_free_port",
+    "trigger_sigint",
+]

--- a/mobipick_gui/__init__.py
+++ b/mobipick_gui/__init__.py
@@ -1,11 +1,14 @@
 """Mobipick Labs GUI package."""
 
+from .logging_utils import configure_logging, get_logger
 from .main_window import MainWindow, trigger_sigint
 from .web_bridge import WebBridge
 from .web_controller import WebController
 from .web_server import WebUiServer, find_free_port
 
 __all__ = [
+    "configure_logging",
+    "get_logger",
     "MainWindow",
     "WebBridge",
     "WebController",

--- a/mobipick_gui/logging_utils.py
+++ b/mobipick_gui/logging_utils.py
@@ -1,0 +1,73 @@
+"""Shared logging helpers for the Mobipick GUI stack."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+_LOGGER_ROOT = "mobipick"
+
+
+class _DebugFormatter(logging.Formatter):
+    """Formatter that renders debug lines in dark green."""
+
+    _GREEN = "\x1b[32m"
+    _RESET = "\x1b[0m"
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401 - inherited docstring
+        message = super().format(record)
+        if record.levelno <= logging.DEBUG:
+            return f"{self._GREEN}{message}{self._RESET}"
+        return message
+
+
+def configure_logging(debug: bool, *, log_file: Optional[Path] = None) -> Optional[Path]:
+    """Configure the shared logger.
+
+    When *debug* is true a stream handler and file handler are registered.
+    Debug output is printed in dark green and persisted to *log_file* (or a
+    default file in the current working directory). When *debug* is false a
+    ``NullHandler`` is installed so modules can log safely without producing
+    terminal noise.
+    """
+
+    logger = logging.getLogger(_LOGGER_ROOT)
+    logger.handlers.clear()
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    if not debug:
+        logger.addHandler(logging.NullHandler())
+        return None
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setLevel(logging.DEBUG)
+    formatter = _DebugFormatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s", "%Y-%m-%d %H:%M:%S")
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+
+    if log_file is None:
+        log_file = Path.cwd() / "mobipick_debug.log"
+    else:
+        log_file = Path(log_file)
+
+    file_handler = logging.FileHandler(log_file, encoding="utf-8")
+    file_handler.setLevel(logging.DEBUG)
+    file_handler.setFormatter(
+        logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s", "%Y-%m-%d %H:%M:%S")
+    )
+    logger.addHandler(file_handler)
+
+    logger.debug("Debug logging enabled; writing to %s", log_file)
+    return log_file
+
+
+def get_logger(name: str | None = None) -> logging.Logger:
+    """Return a module-scoped logger under the shared root."""
+
+    if name:
+        return logging.getLogger(f"{_LOGGER_ROOT}.{name}")
+    return logging.getLogger(_LOGGER_ROOT)
+
+
+__all__ = ["configure_logging", "get_logger"]

--- a/mobipick_gui/main_window.py
+++ b/mobipick_gui/main_window.py
@@ -37,6 +37,7 @@ from PyQt5.QtWidgets import (
 from .ansi import CSI_SEQ_RE, OSC_SEQ_RE, ansi_to_html
 from .config import CONFIG, DEFAULT_YAML_PATH, PROJECT_ROOT, SCRIPT_CLEAN
 from .process_tab import ProcessTab
+from .web_bridge import NullWebBridge, WebBridge
 
 _SIGINT_TRIGGERED = False
 
@@ -48,7 +49,7 @@ def trigger_sigint():
 
 
 class MainWindow(QMainWindow):
-    def __init__(self, verbosity: int = 1):
+    def __init__(self, verbosity: int = 1, *, web_bridge: WebBridge | None = None):
         super().__init__()
 
         try:
@@ -56,6 +57,10 @@ class MainWindow(QMainWindow):
         except (TypeError, ValueError):
             value = 1
         self._verbosity = max(1, min(3, value))
+
+        self._web_bridge = web_bridge or NullWebBridge()
+        if web_bridge is not None:
+            web_bridge.attach_window(self)
 
         window_cfg = CONFIG['window']
         self.setWindowTitle(window_cfg['title'])
@@ -172,6 +177,9 @@ class MainWindow(QMainWindow):
         self.world_combo = QComboBox()
         actions.addWidget(self.world_combo)
         self.world_combo.currentIndexChanged.connect(self._on_world_changed)
+        self.world_combo.currentIndexChanged.connect(
+            lambda _idx: self._publish_combo_state('world', self.world_combo)
+        )
 
         self.image_label = QLabel('image:')
         actions.addWidget(self.image_label)
@@ -179,6 +187,9 @@ class MainWindow(QMainWindow):
         self.image_combo = QComboBox()
         actions.addWidget(self.image_combo)
         self.image_combo.currentIndexChanged.connect(self._on_image_changed)
+        self.image_combo.currentIndexChanged.connect(
+            lambda _idx: self._publish_combo_state('image', self.image_combo)
+        )
 
         self.reload_images_button = QPushButton('Refresh Images')
         self.reload_images_button.clicked.connect(self._reload_images)
@@ -191,6 +202,9 @@ class MainWindow(QMainWindow):
         self.script_combo = QComboBox()
         self.script_combo.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
         scripts_row.addWidget(self.script_combo)
+        self.script_combo.currentIndexChanged.connect(
+            lambda _idx: self._publish_combo_state('script', self.script_combo)
+        )
         self.refresh_scripts_button = QPushButton('Refresh Scripts')
         self.refresh_scripts_button.clicked.connect(self._on_refresh_scripts_clicked)
         scripts_row.addWidget(self.refresh_scripts_button)
@@ -474,6 +488,7 @@ class MainWindow(QMainWindow):
             self.image_combo.setEnabled(False)
         self.image_combo.blockSignals(False)
         self.image_combo.setToolTip(self._selected_image or 'No image selected')
+        self._publish_combo_state('image', self.image_combo)
 
         if show_feedback:
             if choices:
@@ -851,6 +866,7 @@ class MainWindow(QMainWindow):
                 self.script_combo.setCurrentIndex(0)
                 self.script_combo.setEnabled(False)
             self.script_combo.blockSignals(False)
+            self._publish_combo_state('script', self.script_combo)
         script_running = bool(
             self._script_active_tab_key and self._script_active_tab_key in self.tasks and self.tasks[self._script_active_tab_key].is_running()
         )
@@ -1049,6 +1065,7 @@ class MainWindow(QMainWindow):
         if key == 'sim':
             self.tabs.setCurrentIndex(idx)
         self.tasks[key] = tab
+        self._web_bridge.ensure_tab(key, label, closable)
         return tab
 
     def _apply_close_button(self, index: int, closable: bool):
@@ -1123,6 +1140,7 @@ class MainWindow(QMainWindow):
                 pass
         self.tabs.removeTab(index)
         del self.tasks[key]
+        self._web_bridge.remove_tab(key)
 
     def _focus_tab(self, key: str):
         w = self.tasks[key].output
@@ -1167,6 +1185,7 @@ class MainWindow(QMainWindow):
         self.world_combo.setCurrentIndex(index)
         self.world_combo.blockSignals(False)
         self._selected_world = self.world_combo.currentText().strip() or self._default_world
+        self._publish_combo_state('world', self.world_combo)
         self._on_world_changed(self.world_combo.currentIndex())
 
     # ---------- Sim control ----------
@@ -1671,6 +1690,18 @@ class MainWindow(QMainWindow):
         )
         button.setEnabled(enabled)
         self._toggle_states[key] = state
+        self._web_bridge.update_toggle(
+            key,
+            state=state,
+            text=text,
+            enabled=enabled,
+            colors={
+                'bg': bg,
+                'fg': fg,
+                'padding': padding,
+                'disabled_opacity': disabled_opacity,
+            },
+        )
 
     def _disable_toggle_preserving_visual(self, key: str, button: QPushButton):
         current_state = self._toggle_states.get(key, 'red')
@@ -2244,9 +2275,12 @@ class MainWindow(QMainWindow):
         tab = self._prepare_tab_for_origin(key, origin)
         if gui:
             color = html.escape(color or self._gui_log_color)
-            tab.append_line_html(f'<span style="color:{color}">{html_text}</span>')
+            rendered = f'<span style="color:{color}">{html_text}</span>'
+            tab.append_line_html(rendered)
+            self._web_bridge.append_log(key, rendered, origin=origin)
         else:
             tab.append_line_html(html_text)
+            self._web_bridge.append_log(key, html_text, origin=origin)
 
     def _append_gui_html(self, key: str, html_text: str, *, color: str | None = None):
         self._append_html(key, html_text, gui=True, color=color)
@@ -2285,6 +2319,11 @@ class MainWindow(QMainWindow):
     @staticmethod
     def _sh_quote(s: str) -> str:
         return "'" + s.replace("'", "'\\''") + "'"
+
+    def _publish_combo_state(self, name: str, combo: QComboBox):
+        options = [combo.itemText(i) for i in range(combo.count())]
+        current = combo.currentText() if combo.currentIndex() >= 0 else None
+        self._web_bridge.update_combobox(name, options=options, current=current)
 
     # ---------- Search within current tab ----------
 

--- a/mobipick_gui/main_window.py
+++ b/mobipick_gui/main_window.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import html
+import logging
 import os
 import re
 import shlex
@@ -37,15 +38,20 @@ from PyQt5.QtWidgets import (
 from .ansi import CSI_SEQ_RE, OSC_SEQ_RE, ansi_to_html
 from .config import CONFIG, DEFAULT_YAML_PATH, PROJECT_ROOT, SCRIPT_CLEAN
 from .process_tab import ProcessTab
+from .logging_utils import get_logger
 from .web_bridge import NullWebBridge, WebBridge
 
 _SIGINT_TRIGGERED = False
+
+
+logger = get_logger(__name__)
 
 
 def trigger_sigint():
     """Signal the GUI to start its shutdown sequence."""
     global _SIGINT_TRIGGERED
     _SIGINT_TRIGGERED = True
+    logger.debug('trigger_sigint set flag to %s', _SIGINT_TRIGGERED)
 
 
 class MainWindow(QMainWindow):
@@ -61,6 +67,7 @@ class MainWindow(QMainWindow):
         self._web_bridge = web_bridge or NullWebBridge()
         if web_bridge is not None:
             web_bridge.attach_window(self)
+        logger.debug('MainWindow initialized (verbosity=%d, web_bridge=%s)', self._verbosity, type(self._web_bridge).__name__)
 
         window_cfg = CONFIG['window']
         self.setWindowTitle(window_cfg['title'])
@@ -539,6 +546,8 @@ class MainWindow(QMainWindow):
         return bool(args_or_str) and args_or_str[0] == 'docker'
 
     def _console_log(self, level: int, message: str):
+        log_level = logging.INFO if level <= 1 else logging.DEBUG
+        logger.log(log_level, message)
         if self._verbosity >= level:
             print(message, flush=True)
 

--- a/mobipick_gui/web_assets.py
+++ b/mobipick_gui/web_assets.py
@@ -1,0 +1,561 @@
+"""Static assets served by the lightweight web UI server."""
+
+INDEX_HTML = r"""<!DOCTYPE html>
+<html lang=\"en\">
+  <head>
+    <meta charset=\"utf-8\" />
+    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
+    <title>Mobipick Labs Control (Web)</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        background: #101014;
+        color: #e9ecef;
+      }
+      body {
+        margin: 0;
+        padding: 0;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+      header {
+        padding: 1rem 1.5rem;
+        background: #1f1f28;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        align-items: center;
+        justify-content: space-between;
+      }
+      header h1 {
+        font-size: 1.4rem;
+        margin: 0;
+      }
+      main {
+        flex: 1;
+        padding: 1rem 1.5rem 2.5rem;
+        display: grid;
+        grid-template-columns: minmax(260px, 320px) 1fr;
+        gap: 1.5rem;
+      }
+      @media (max-width: 1024px) {
+        main {
+          grid-template-columns: 1fr;
+        }
+      }
+      .panel {
+        background: #191926;
+        border-radius: 12px;
+        padding: 1rem 1.25rem;
+        box-shadow: 0 10px 25px rgba(0, 0, 0, 0.35);
+      }
+      #control-panel h2,
+      #layout-panel h2 {
+        font-size: 1.1rem;
+        margin: 0 0 0.75rem 0;
+      }
+      #toggle-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 0.75rem;
+      }
+      .toggle-button {
+        border: none;
+        border-radius: 10px;
+        padding: 0.8rem 0.6rem;
+        font-size: 0.95rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.12s ease, filter 0.12s ease;
+      }
+      .toggle-button:disabled {
+        cursor: not-allowed;
+        opacity: 0.6;
+      }
+      .toggle-button:not(:disabled):hover {
+        transform: translateY(-1px);
+        filter: brightness(1.1);
+      }
+      .combo-group {
+        margin-top: 1rem;
+        display: grid;
+        gap: 0.75rem;
+      }
+      .combo-group label {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+        font-size: 0.9rem;
+      }
+      .combo-group select {
+        border-radius: 8px;
+        padding: 0.5rem 0.6rem;
+        border: 1px solid rgba(255,255,255,0.08);
+        background: #1f1f2c;
+        color: inherit;
+      }
+      #actions-row {
+        margin-top: 1rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.6rem;
+      }
+      #actions-row button {
+        border-radius: 8px;
+        padding: 0.45rem 0.9rem;
+        border: 1px solid rgba(255,255,255,0.12);
+        background: transparent;
+        color: inherit;
+        cursor: pointer;
+        transition: background 0.12s ease;
+      }
+      #actions-row button:hover {
+        background: rgba(255,255,255,0.08);
+      }
+      #layout-panel {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+      #layout-config {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        align-items: center;
+      }
+      #layout-config select {
+        border-radius: 8px;
+        padding: 0.4rem 0.7rem;
+        border: 1px solid rgba(255,255,255,0.12);
+        background: #1f1f2c;
+        color: inherit;
+      }
+      #tab-selector {
+        display: grid;
+        gap: 0.4rem;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      }
+      #tab-selector label {
+        background: rgba(255,255,255,0.05);
+        padding: 0.45rem 0.6rem;
+        border-radius: 8px;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+      #log-container {
+        display: grid;
+        gap: 1rem;
+      }
+      #log-container.columns-1 {
+        grid-template-columns: 1fr;
+      }
+      #log-container.columns-2 {
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+      #log-container.columns-3 {
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      }
+      .log-card {
+        background: rgba(17, 18, 30, 0.92);
+        border-radius: 12px;
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+        border: 1px solid rgba(255,255,255,0.05);
+      }
+      .log-card header {
+        background: rgba(255,255,255,0.05);
+        padding: 0.6rem 0.85rem;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      .log-card header h3 {
+        margin: 0;
+        font-size: 1rem;
+        font-weight: 600;
+      }
+      .log-card header button {
+        border: none;
+        border-radius: 6px;
+        padding: 0.25rem 0.55rem;
+        background: rgba(255,255,255,0.08);
+        color: inherit;
+        cursor: pointer;
+      }
+      .log-scroll {
+        overflow-y: auto;
+        max-height: 380px;
+        padding: 0.8rem 0.85rem;
+        font-family: Menlo, Consolas, "Fira Code", monospace;
+        font-size: 0.85rem;
+        line-height: 1.35rem;
+        background: rgba(0, 0, 0, 0.35);
+      }
+      .log-line {
+        padding-bottom: 0.2rem;
+      }
+      .log-line.origin-gui {
+        color: #50fa7b;
+      }
+      .log-line.origin-container {
+        color: #f8f9fa;
+      }
+      .status-pill {
+        background: rgba(80, 250, 123, 0.15);
+        border-radius: 999px;
+        padding: 0.15rem 0.6rem;
+        font-size: 0.8rem;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Mobipick Labs Control (Web)</h1>
+      <div id=\"status-line\" class=\"status-pill\">Connecting...</div>
+    </header>
+    <main>
+      <section id=\"control-panel\" class=\"panel\">
+        <h2>Primary Controls</h2>
+        <div id=\"toggle-grid\"></div>
+        <div class=\"combo-group\" id=\"combo-group\"></div>
+        <div id=\"actions-row\">
+          <button data-action=\"refresh_status\">Refresh Status</button>
+          <button data-action=\"refresh_images\">Refresh Images</button>
+          <button data-action=\"refresh_scripts\">Refresh Scripts</button>
+        </div>
+      </section>
+      <section id=\"layout-panel\" class=\"panel\">
+        <div>
+          <h2>Embedded Process Layout</h2>
+          <div id=\"layout-config\">
+            <label>
+              View Mode:
+              <select id=\"layout-select\">
+                <option value=\"1\">Single Column</option>
+                <option value=\"2\" selected>Two Columns</option>
+                <option value=\"3\">Three Columns</option>
+              </select>
+            </label>
+          </div>
+        </div>
+        <div>
+          <h2>Visible Tabs</h2>
+          <div id=\"tab-selector\"></div>
+        </div>
+      </section>
+      <section id=\"log-panel\" class=\"panel\" style=\"grid-column: 1 / -1;\">
+        <h2>Processes &amp; Logs</h2>
+        <div id=\"log-container\" class=\"columns-2\"></div>
+      </section>
+    </main>
+    <script>
+      const state = {
+        toggles: {},
+        tabs: {},
+        combobox: {},
+        status: {},
+        selectedTabs: new Set(),
+        layoutColumns: 2,
+        lastEvent: 0,
+      };
+
+      async function getJSON(url) {
+        const res = await fetch(url, { cache: 'no-store' });
+        if (!res.ok) {
+          throw new Error(`Request failed: ${res.status}`);
+        }
+        return res.json();
+      }
+
+      async function postJSON(url, body) {
+        const res = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) {
+          const text = await res.text();
+          throw new Error(`Request failed: ${res.status} ${text}`);
+        }
+        return res.json();
+      }
+
+      function applySnapshot(snapshot) {
+        state.toggles = snapshot.toggles || {};
+        state.combobox = snapshot.combobox || {};
+        state.status = snapshot.status || {};
+        state.tabs = {};
+        const tabs = snapshot.tabs || {};
+        Object.keys(tabs).forEach((key) => {
+          const tab = tabs[key];
+          state.tabs[key] = {
+            key,
+            label: tab.label || key,
+            closable: Boolean(tab.closable),
+            logs: Array.isArray(tab.logs) ? tab.logs.slice() : [],
+          };
+        });
+        const events = snapshot.events || [];
+        events.forEach((evt) => {
+          state.lastEvent = Math.max(state.lastEvent, evt.id || 0);
+          applyEvent(evt);
+        });
+        if (!state.selectedTabs.size) {
+          Object.keys(state.tabs).slice(0, 3).forEach((key) => state.selectedTabs.add(key));
+        }
+        renderAll();
+      }
+
+      function applyEvent(evt) {
+        if (!evt || !evt.type) return;
+        const payload = evt.payload || {};
+        switch (evt.type) {
+          case 'toggle':
+            state.toggles[payload.key] = payload;
+            break;
+          case 'tab': {
+            const key = payload.key;
+            if (!key) break;
+            const existing = state.tabs[key];
+            if (existing) {
+              existing.label = payload.label || existing.label;
+              existing.closable = Boolean(payload.closable);
+            } else {
+              state.tabs[key] = {
+                key,
+                label: payload.label || key,
+                closable: Boolean(payload.closable),
+                logs: [],
+              };
+            }
+            break;
+          }
+          case 'tab_removed':
+            if (payload.key && state.tabs[payload.key]) {
+              delete state.tabs[payload.key];
+              state.selectedTabs.delete(payload.key);
+            }
+            break;
+          case 'log': {
+            const key = payload.key;
+            if (!state.tabs[key]) {
+              state.tabs[key] = { key, label: key, closable: true, logs: [] };
+            }
+            const tab = state.tabs[key];
+            tab.logs.push({ html: payload.html || '', origin: payload.origin || 'container' });
+            if (tab.logs.length > 400) {
+              tab.logs.splice(0, tab.logs.length - 400);
+            }
+            break;
+          }
+          case 'combobox':
+            state.combobox[payload.name] = {
+              options: payload.options || [],
+              current: payload.current || null,
+            };
+            break;
+          case 'status':
+            state.status[payload.key] = payload.value;
+            break;
+          case 'shutdown':
+            document.getElementById('status-line').textContent = 'Application shutting down';
+            break;
+          default:
+            break;
+        }
+      }
+
+      function renderAll() {
+        renderToggles();
+        renderCombos();
+        renderTabSelector();
+        renderLogs();
+        updateStatusLine();
+      }
+
+      function renderToggles() {
+        const grid = document.getElementById('toggle-grid');
+        grid.innerHTML = '';
+        Object.keys(state.toggles).forEach((key) => {
+          const data = state.toggles[key];
+          const btn = document.createElement('button');
+          btn.className = 'toggle-button';
+          btn.dataset.toggle = key;
+          btn.textContent = data.text || key;
+          btn.disabled = !data.enabled;
+          const colors = data.colors || {};
+          btn.style.backgroundColor = colors.bg || '#343a40';
+          btn.style.color = colors.fg || '#fff';
+          btn.style.padding = `${colors.padding || 6}px`;
+          btn.addEventListener('click', () => handleAction(`toggle_${key}`));
+          grid.appendChild(btn);
+        });
+      }
+
+      function renderCombos() {
+        const wrapper = document.getElementById('combo-group');
+        wrapper.innerHTML = '';
+        Object.entries(state.combobox).forEach(([name, data]) => {
+          const label = document.createElement('label');
+          label.textContent = `${name} configuration`;
+          const select = document.createElement('select');
+          (data.options || []).forEach((opt) => {
+            const option = document.createElement('option');
+            option.value = opt;
+            option.textContent = opt;
+            if (opt === data.current) {
+              option.selected = true;
+            }
+            select.appendChild(option);
+          });
+          select.addEventListener('change', () => handleAction('set_combo', { name, value: select.value }));
+          label.appendChild(select);
+          wrapper.appendChild(label);
+        });
+      }
+
+      function renderTabSelector() {
+        const container = document.getElementById('tab-selector');
+        container.innerHTML = '';
+        Object.values(state.tabs)
+          .sort((a, b) => a.label.localeCompare(b.label))
+          .forEach((tab) => {
+            const label = document.createElement('label');
+            const cb = document.createElement('input');
+            cb.type = 'checkbox';
+            cb.checked = state.selectedTabs.has(tab.key);
+            cb.addEventListener('change', () => {
+              if (cb.checked) {
+                state.selectedTabs.add(tab.key);
+              } else {
+                state.selectedTabs.delete(tab.key);
+              }
+              renderLogs();
+            });
+            const span = document.createElement('span');
+            span.textContent = tab.label;
+            label.appendChild(cb);
+            label.appendChild(span);
+            container.appendChild(label);
+          });
+      }
+
+      function renderLogs() {
+        const container = document.getElementById('log-container');
+        container.className = `columns-${state.layoutColumns}`;
+        container.innerHTML = '';
+        Array.from(state.selectedTabs)
+          .filter((key) => state.tabs[key])
+          .forEach((key) => {
+            const tab = state.tabs[key];
+            const card = document.createElement('div');
+            card.className = 'log-card';
+            const header = document.createElement('header');
+            const title = document.createElement('h3');
+            title.textContent = tab.label;
+            header.appendChild(title);
+            const pop = document.createElement('button');
+            pop.textContent = 'Pop-out';
+            pop.addEventListener('click', () => openTabWindow(tab));
+            header.appendChild(pop);
+            card.appendChild(header);
+            const scroller = document.createElement('div');
+            scroller.className = 'log-scroll';
+            scroller.innerHTML = tab.logs
+              .map((line) => `<div class=\"log-line origin-${line.origin || 'container'}\">${line.html || ''}</div>`)
+              .join('');
+            scroller.scrollTop = scroller.scrollHeight;
+            card.appendChild(scroller);
+            container.appendChild(card);
+          });
+      }
+
+      function openTabWindow(tab) {
+        const popup = window.open('', `_tab_${tab.key}`, 'width=720,height=560');
+        if (!popup) return;
+        popup.document.write(`<!DOCTYPE html><html><head><title>${tab.label}</title>` +
+          '<meta charset="utf-8" /><style>body{background:#0b0b10;color:#f8f9fa;font-family:Menlo,monospace;padding:1rem;}h1{font-size:1.2rem;margin-bottom:0.75rem;}div{line-height:1.35rem;font-size:0.9rem;} .log-line{margin-bottom:0.25rem;} .origin-gui{color:#50fa7b;}</style></head><body>' +
+          `<h1>${tab.label}</h1><div id="log-view"></div></body></html>`);
+        popup.document.close();
+        const target = popup.document.getElementById('log-view');
+        target.innerHTML = tab.logs
+          .map((line) => `<div class="log-line ${line.origin ? `origin-${line.origin}` : ''}">${line.html || ''}</div>`)
+          .join('');
+      }
+
+      function updateStatusLine() {
+        const element = document.getElementById('status-line');
+        if (!element) return;
+        const pieces = [];
+        if (state.toggles.sim) {
+          pieces.push(`Sim: ${state.toggles.sim.state || 'unknown'}`);
+        }
+        if (state.toggles.roscore) {
+          pieces.push(`Roscore: ${state.toggles.roscore.state || 'unknown'}`);
+        }
+        element.textContent = pieces.length ? pieces.join(' • ') : 'Ready';
+      }
+
+      async function handleAction(action, payload = {}) {
+        try {
+          await postJSON('/api/action', { action, payload });
+        } catch (err) {
+          console.error(err);
+          alert(err.message || 'Action failed');
+        }
+      }
+
+      async function pollEvents() {
+        try {
+          const events = await getJSON(`/api/events?since=${state.lastEvent}`);
+          events.forEach((evt) => {
+            state.lastEvent = Math.max(state.lastEvent, evt.id || 0);
+            applyEvent(evt);
+          });
+          renderLogs();
+          renderToggles();
+          updateStatusLine();
+        } catch (err) {
+          console.warn('Polling failed', err);
+          document.getElementById('status-line').textContent = 'Connection lost – retrying…';
+        }
+      }
+
+      function initLayoutControls() {
+        const layoutSelect = document.getElementById('layout-select');
+        layoutSelect.value = String(state.layoutColumns);
+        layoutSelect.addEventListener('change', () => {
+          state.layoutColumns = Number(layoutSelect.value) || 1;
+          renderLogs();
+        });
+        document.querySelectorAll('#actions-row button').forEach((btn) => {
+          btn.addEventListener('click', () => handleAction(btn.dataset.action));
+        });
+      }
+
+      async function bootstrap() {
+        try {
+          const snapshot = await getJSON('/api/snapshot');
+          applySnapshot(snapshot);
+          initLayoutControls();
+          document.getElementById('status-line').textContent = 'Connected';
+          setInterval(pollEvents, 1200);
+        } catch (err) {
+          console.error(err);
+          document.getElementById('status-line').textContent = 'Failed to connect';
+        }
+      }
+
+      bootstrap();
+    </script>
+  </body>
+</html>
+"""
+
+__all__ = ["INDEX_HTML"]
+

--- a/mobipick_gui/web_assets.py
+++ b/mobipick_gui/web_assets.py
@@ -254,304 +254,555 @@ INDEX_HTML = r"""<!DOCTYPE html>
       </section>
     </main>
     <script>
-      const state = {
-        toggles: {},
-        tabs: {},
-        combobox: {},
-        status: {},
-        selectedTabs: new Set(),
-        layoutColumns: 2,
-        lastEvent: 0,
-      };
+      (function () {
+        'use strict';
 
-      async function getJSON(url) {
-        const res = await fetch(url, { cache: 'no-store' });
-        if (!res.ok) {
-          throw new Error(`Request failed: ${res.status}`);
+        var state = {
+          toggles: {},
+          tabs: {},
+          combobox: {},
+          status: {},
+          selectedTabs: [],
+          layoutColumns: 2,
+          lastEvent: 0
+        };
+
+        function hasOwn(obj, key) {
+          return Object.prototype.hasOwnProperty.call(obj, key);
         }
-        return res.json();
-      }
 
-      async function postJSON(url, body) {
-        const res = await fetch(url, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(body),
-        });
-        if (!res.ok) {
-          const text = await res.text();
-          throw new Error(`Request failed: ${res.status} ${text}`);
+        function isArray(value) {
+          return Object.prototype.toString.call(value) === '[object Array]';
         }
-        return res.json();
-      }
 
-      function applySnapshot(snapshot) {
-        state.toggles = snapshot.toggles || {};
-        state.combobox = snapshot.combobox || {};
-        state.status = snapshot.status || {};
-        state.tabs = {};
-        const tabs = snapshot.tabs || {};
-        Object.keys(tabs).forEach((key) => {
-          const tab = tabs[key];
-          state.tabs[key] = {
-            key,
-            label: tab.label || key,
-            closable: Boolean(tab.closable),
-            logs: Array.isArray(tab.logs) ? tab.logs.slice() : [],
-          };
-        });
-        const events = snapshot.events || [];
-        events.forEach((evt) => {
-          state.lastEvent = Math.max(state.lastEvent, evt.id || 0);
-          applyEvent(evt);
-        });
-        if (!state.selectedTabs.size) {
-          Object.keys(state.tabs).slice(0, 3).forEach((key) => state.selectedTabs.add(key));
+        function escapeHtml(text) {
+          if (text === undefined || text === null) {
+            return '';
+          }
+          return String(text)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
         }
-        renderAll();
-      }
 
-      function applyEvent(evt) {
-        if (!evt || !evt.type) return;
-        const payload = evt.payload || {};
-        switch (evt.type) {
-          case 'toggle':
-            state.toggles[payload.key] = payload;
-            break;
-          case 'tab': {
-            const key = payload.key;
-            if (!key) break;
-            const existing = state.tabs[key];
-            if (existing) {
-              existing.label = payload.label || existing.label;
-              existing.closable = Boolean(payload.closable);
-            } else {
+        function safeOriginClass(origin) {
+          var value = origin || 'container';
+          return value.replace(/[^a-zA-Z0-9_-]/g, '');
+        }
+
+        function hasSelectedTab(key) {
+          return state.selectedTabs.indexOf(key) !== -1;
+        }
+
+        function addSelectedTab(key) {
+          if (!hasSelectedTab(key)) {
+            state.selectedTabs.push(key);
+          }
+        }
+
+        function removeSelectedTab(key) {
+          var idx = state.selectedTabs.indexOf(key);
+          if (idx !== -1) {
+            state.selectedTabs.splice(idx, 1);
+          }
+        }
+
+        function filterSelectedTabs() {
+          for (var i = state.selectedTabs.length - 1; i >= 0; i -= 1) {
+            var key = state.selectedTabs[i];
+            if (!hasOwn(state.tabs, key)) {
+              state.selectedTabs.splice(i, 1);
+            }
+          }
+        }
+
+        function setStatus(text) {
+          var element = document.getElementById('status-line');
+          if (element) {
+            element.textContent = text;
+          }
+        }
+
+        function getJSON(url) {
+          if (typeof window.fetch === 'function') {
+            return fetch(url, { cache: 'no-store' }).then(function (res) {
+              if (!res.ok) {
+                throw new Error('Request failed: ' + res.status);
+              }
+              return res.json();
+            });
+          }
+          return new Promise(function (resolve, reject) {
+            var xhr = new XMLHttpRequest();
+            xhr.open('GET', url, true);
+            xhr.setRequestHeader('Cache-Control', 'no-store');
+            xhr.onreadystatechange = function () {
+              if (xhr.readyState === 4) {
+                if (xhr.status >= 200 && xhr.status < 300) {
+                  try {
+                    resolve(JSON.parse(xhr.responseText || 'null'));
+                  } catch (err) {
+                    reject(err);
+                  }
+                } else {
+                  reject(new Error('Request failed: ' + xhr.status));
+                }
+              }
+            };
+            xhr.onerror = function () {
+              reject(new Error('Network error'));
+            };
+            xhr.send(null);
+          });
+        }
+
+        function postJSON(url, body) {
+          if (typeof window.fetch === 'function') {
+            return fetch(url, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(body)
+            }).then(function (res) {
+              if (!res.ok) {
+                return res.text().then(function (text) {
+                  throw new Error('Request failed: ' + res.status + ' ' + text);
+                });
+              }
+              return res.json();
+            });
+          }
+          return new Promise(function (resolve, reject) {
+            var xhr = new XMLHttpRequest();
+            xhr.open('POST', url, true);
+            xhr.setRequestHeader('Content-Type', 'application/json');
+            xhr.onreadystatechange = function () {
+              if (xhr.readyState === 4) {
+                if (xhr.status >= 200 && xhr.status < 300) {
+                  try {
+                    resolve(JSON.parse(xhr.responseText || 'null'));
+                  } catch (err) {
+                    reject(err);
+                  }
+                } else {
+                  reject(new Error('Request failed: ' + xhr.status + ' ' + (xhr.responseText || '')));
+                }
+              }
+            };
+            xhr.onerror = function () {
+              reject(new Error('Network error'));
+            };
+            xhr.send(JSON.stringify(body || {}));
+          });
+        }
+
+        function applySnapshot(snapshot) {
+          state.toggles = snapshot && snapshot.toggles ? snapshot.toggles : {};
+          state.combobox = snapshot && snapshot.combobox ? snapshot.combobox : {};
+          state.status = snapshot && snapshot.status ? snapshot.status : {};
+          state.tabs = {};
+
+          var tabs = snapshot && snapshot.tabs ? snapshot.tabs : {};
+          for (var key in tabs) {
+            if (hasOwn(tabs, key)) {
+              var tab = tabs[key] || {};
               state.tabs[key] = {
-                key,
-                label: payload.label || key,
-                closable: Boolean(payload.closable),
-                logs: [],
+                key: key,
+                label: tab.label || key,
+                closable: !!tab.closable,
+                logs: isArray(tab.logs) ? tab.logs.slice(0) : []
               };
             }
-            break;
           }
-          case 'tab_removed':
-            if (payload.key && state.tabs[payload.key]) {
-              delete state.tabs[payload.key];
-              state.selectedTabs.delete(payload.key);
+
+          var events = snapshot && snapshot.events ? snapshot.events : [];
+          for (var i = 0; i < events.length; i += 1) {
+            var evt = events[i];
+            if (evt && evt.id && evt.id > state.lastEvent) {
+              state.lastEvent = evt.id;
             }
-            break;
-          case 'log': {
-            const key = payload.key;
-            if (!state.tabs[key]) {
-              state.tabs[key] = { key, label: key, closable: true, logs: [] };
-            }
-            const tab = state.tabs[key];
-            tab.logs.push({ html: payload.html || '', origin: payload.origin || 'container' });
-            if (tab.logs.length > 400) {
-              tab.logs.splice(0, tab.logs.length - 400);
-            }
-            break;
+            applyEvent(evt);
           }
-          case 'combobox':
-            state.combobox[payload.name] = {
-              options: payload.options || [],
-              current: payload.current || null,
-            };
-            break;
-          case 'status':
-            state.status[payload.key] = payload.value;
-            break;
-          case 'shutdown':
-            document.getElementById('status-line').textContent = 'Application shutting down';
-            break;
-          default:
-            break;
-        }
-      }
 
-      function renderAll() {
-        renderToggles();
-        renderCombos();
-        renderTabSelector();
-        renderLogs();
-        updateStatusLine();
-      }
-
-      function renderToggles() {
-        const grid = document.getElementById('toggle-grid');
-        grid.innerHTML = '';
-        Object.keys(state.toggles).forEach((key) => {
-          const data = state.toggles[key];
-          const btn = document.createElement('button');
-          btn.className = 'toggle-button';
-          btn.dataset.toggle = key;
-          btn.textContent = data.text || key;
-          btn.disabled = !data.enabled;
-          const colors = data.colors || {};
-          btn.style.backgroundColor = colors.bg || '#343a40';
-          btn.style.color = colors.fg || '#fff';
-          btn.style.padding = `${colors.padding || 6}px`;
-          btn.addEventListener('click', () => handleAction(`toggle_${key}`));
-          grid.appendChild(btn);
-        });
-      }
-
-      function renderCombos() {
-        const wrapper = document.getElementById('combo-group');
-        wrapper.innerHTML = '';
-        Object.entries(state.combobox).forEach(([name, data]) => {
-          const label = document.createElement('label');
-          label.textContent = `${name} configuration`;
-          const select = document.createElement('select');
-          (data.options || []).forEach((opt) => {
-            const option = document.createElement('option');
-            option.value = opt;
-            option.textContent = opt;
-            if (opt === data.current) {
-              option.selected = true;
-            }
-            select.appendChild(option);
-          });
-          select.addEventListener('change', () => handleAction('set_combo', { name, value: select.value }));
-          label.appendChild(select);
-          wrapper.appendChild(label);
-        });
-      }
-
-      function renderTabSelector() {
-        const container = document.getElementById('tab-selector');
-        container.innerHTML = '';
-        Object.values(state.tabs)
-          .sort((a, b) => a.label.localeCompare(b.label))
-          .forEach((tab) => {
-            const label = document.createElement('label');
-            const cb = document.createElement('input');
-            cb.type = 'checkbox';
-            cb.checked = state.selectedTabs.has(tab.key);
-            cb.addEventListener('change', () => {
-              if (cb.checked) {
-                state.selectedTabs.add(tab.key);
-              } else {
-                state.selectedTabs.delete(tab.key);
+          if (!state.selectedTabs.length) {
+            var count = 0;
+            for (var tabKey in state.tabs) {
+              if (hasOwn(state.tabs, tabKey)) {
+                addSelectedTab(tabKey);
+                count += 1;
+                if (count >= 3) {
+                  break;
+                }
               }
-              renderLogs();
-            });
-            const span = document.createElement('span');
+            }
+          }
+
+          renderAll();
+        }
+
+        function applyEvent(evt) {
+          if (!evt || !evt.type) {
+            return;
+          }
+          var payload = evt.payload || {};
+          switch (evt.type) {
+            case 'toggle':
+              if (payload.key) {
+                state.toggles[payload.key] = payload;
+              }
+              break;
+            case 'tab':
+              if (!payload.key) {
+                break;
+              }
+              if (hasOwn(state.tabs, payload.key)) {
+                var existing = state.tabs[payload.key];
+                existing.label = payload.label || existing.label;
+                existing.closable = !!payload.closable;
+              } else {
+                state.tabs[payload.key] = {
+                  key: payload.key,
+                  label: payload.label || payload.key,
+                  closable: !!payload.closable,
+                  logs: []
+                };
+              }
+              break;
+            case 'tab_removed':
+              if (payload.key && hasOwn(state.tabs, payload.key)) {
+                delete state.tabs[payload.key];
+                removeSelectedTab(payload.key);
+              }
+              break;
+            case 'log':
+              if (!payload.key) {
+                break;
+              }
+              if (!hasOwn(state.tabs, payload.key)) {
+                state.tabs[payload.key] = {
+                  key: payload.key,
+                  label: payload.key,
+                  closable: true,
+                  logs: []
+                };
+              }
+              var tab = state.tabs[payload.key];
+              tab.logs.push({
+                html: payload.html || '',
+                origin: payload.origin || 'container'
+              });
+              if (tab.logs.length > 400) {
+                tab.logs.splice(0, tab.logs.length - 400);
+              }
+              break;
+            case 'combobox':
+              if (payload.name) {
+                state.combobox[payload.name] = {
+                  options: payload.options || [],
+                  current: payload.current || null
+                };
+              }
+              break;
+            case 'status':
+              if (payload.key) {
+                state.status[payload.key] = payload.value;
+              }
+              break;
+            case 'shutdown':
+              setStatus('Application shutting down');
+              break;
+            default:
+              break;
+          }
+        }
+
+        function renderAll() {
+          renderToggles();
+          renderCombos();
+          renderTabSelector();
+          renderLogs();
+          updateStatusLine();
+        }
+
+        function renderToggles() {
+          var grid = document.getElementById('toggle-grid');
+          if (!grid) {
+            return;
+          }
+          grid.innerHTML = '';
+          for (var key in state.toggles) {
+            if (!hasOwn(state.toggles, key)) {
+              continue;
+            }
+            var data = state.toggles[key] || {};
+            var btn = document.createElement('button');
+            btn.className = 'toggle-button';
+            btn.setAttribute('data-toggle', key);
+            btn.textContent = data.text || key;
+            btn.disabled = !data.enabled;
+            var colors = data.colors || {};
+            var padding = colors.padding !== undefined && colors.padding !== null ? colors.padding : 6;
+            btn.style.backgroundColor = colors.bg || '#343a40';
+            btn.style.color = colors.fg || '#fff';
+            btn.style.padding = String(padding) + 'px';
+            btn.onclick = (function (toggleKey) {
+              return function () {
+                handleAction('toggle_' + toggleKey);
+              };
+            })(key);
+            grid.appendChild(btn);
+          }
+        }
+
+        function renderCombos() {
+          var wrapper = document.getElementById('combo-group');
+          if (!wrapper) {
+            return;
+          }
+          wrapper.innerHTML = '';
+          for (var name in state.combobox) {
+            if (!hasOwn(state.combobox, name)) {
+              continue;
+            }
+            var data = state.combobox[name] || {};
+            var label = document.createElement('label');
+            label.textContent = name + ' configuration';
+            var select = document.createElement('select');
+            var options = data.options || [];
+            for (var i = 0; i < options.length; i += 1) {
+              var opt = document.createElement('option');
+              opt.value = options[i];
+              opt.textContent = options[i];
+              if (options[i] === data.current) {
+                opt.selected = true;
+              }
+              select.appendChild(opt);
+            }
+            select.onchange = (function (comboName, element) {
+              return function () {
+                handleAction('set_combo', { name: comboName, value: element.value });
+              };
+            })(name, select);
+            label.appendChild(select);
+            wrapper.appendChild(label);
+          }
+        }
+
+        function renderTabSelector() {
+          var container = document.getElementById('tab-selector');
+          if (!container) {
+            return;
+          }
+          container.innerHTML = '';
+          var tabsArray = [];
+          for (var key in state.tabs) {
+            if (hasOwn(state.tabs, key)) {
+              tabsArray.push(state.tabs[key]);
+            }
+          }
+          tabsArray.sort(function (a, b) {
+            var aLabel = a.label || '';
+            var bLabel = b.label || '';
+            if (aLabel < bLabel) return -1;
+            if (aLabel > bLabel) return 1;
+            return 0;
+          });
+          for (var i = 0; i < tabsArray.length; i += 1) {
+            var tab = tabsArray[i];
+            var label = document.createElement('label');
+            var cb = document.createElement('input');
+            cb.type = 'checkbox';
+            cb.checked = hasSelectedTab(tab.key);
+            cb.onchange = (function (tabKey, checkbox) {
+              return function () {
+                if (checkbox.checked) {
+                  addSelectedTab(tabKey);
+                } else {
+                  removeSelectedTab(tabKey);
+                }
+                renderLogs();
+              };
+            })(tab.key, cb);
+            var span = document.createElement('span');
             span.textContent = tab.label;
             label.appendChild(cb);
             label.appendChild(span);
             container.appendChild(label);
-          });
-      }
+          }
+        }
 
-      function renderLogs() {
-        const container = document.getElementById('log-container');
-        container.className = `columns-${state.layoutColumns}`;
-        container.innerHTML = '';
-        Array.from(state.selectedTabs)
-          .filter((key) => state.tabs[key])
-          .forEach((key) => {
-            const tab = state.tabs[key];
-            const card = document.createElement('div');
+        function renderLogs() {
+          var container = document.getElementById('log-container');
+          if (!container) {
+            return;
+          }
+          filterSelectedTabs();
+          container.className = 'columns-' + state.layoutColumns;
+          container.innerHTML = '';
+          for (var i = 0; i < state.selectedTabs.length; i += 1) {
+            var key = state.selectedTabs[i];
+            if (!hasOwn(state.tabs, key)) {
+              continue;
+            }
+            var tab = state.tabs[key];
+            var card = document.createElement('div');
             card.className = 'log-card';
-            const header = document.createElement('header');
-            const title = document.createElement('h3');
+            var header = document.createElement('header');
+            var title = document.createElement('h3');
             title.textContent = tab.label;
             header.appendChild(title);
-            const pop = document.createElement('button');
+            var pop = document.createElement('button');
             pop.textContent = 'Pop-out';
-            pop.addEventListener('click', () => openTabWindow(tab));
+            pop.onclick = (function (tabData) {
+              return function () {
+                openTabWindow(tabData);
+              };
+            })(tab);
             header.appendChild(pop);
             card.appendChild(header);
-            const scroller = document.createElement('div');
+            var scroller = document.createElement('div');
             scroller.className = 'log-scroll';
-            scroller.innerHTML = tab.logs
-              .map((line) => `<div class=\"log-line origin-${line.origin || 'container'}\">${line.html || ''}</div>`)
-              .join('');
+            var html = '';
+            for (var j = 0; j < tab.logs.length; j += 1) {
+              var line = tab.logs[j] || {};
+              html += '<div class="log-line origin-' + safeOriginClass(line.origin) + '">' + (line.html || '') + '</div>';
+            }
+            scroller.innerHTML = html;
             scroller.scrollTop = scroller.scrollHeight;
             card.appendChild(scroller);
             container.appendChild(card);
+          }
+        }
+
+        function openTabWindow(tab) {
+          var popup = window.open('', '_tab_' + tab.key, 'width=720,height=560');
+          if (!popup) {
+            return;
+          }
+          var label = escapeHtml(tab.label || tab.key);
+          var doc = popup.document;
+          doc.open();
+          doc.write('<!DOCTYPE html><html><head><meta charset="utf-8" />' +
+            '<title>' + label + '</title>' +
+            '<style>body{background:#0b0b10;color:#f8f9fa;font-family:Menlo,monospace;padding:1rem;}' +
+            'h1{font-size:1.2rem;margin-bottom:0.75rem;}div{line-height:1.35rem;font-size:0.9rem;}' +
+            '.log-line{margin-bottom:0.25rem;}.origin-gui{color:#50fa7b;}</style></head><body>' +
+            '<h1>' + label + '</h1><div id="log-view"></div></body></html>');
+          doc.close();
+          var target = doc.getElementById('log-view');
+          if (target) {
+            var html = '';
+            for (var i = 0; i < tab.logs.length; i += 1) {
+              var line = tab.logs[i] || {};
+              html += '<div class="log-line ' + safeOriginClass(line.origin) + '">' + (line.html || '') + '</div>';
+            }
+            target.innerHTML = html;
+          }
+        }
+
+        function updateStatusLine() {
+          var pieces = [];
+          if (hasOwn(state.toggles, 'sim')) {
+            var simState = state.toggles.sim && state.toggles.sim.state ? state.toggles.sim.state : 'unknown';
+            pieces.push('Sim: ' + simState);
+          }
+          if (hasOwn(state.toggles, 'roscore')) {
+            var roscoreState = state.toggles.roscore && state.toggles.roscore.state ? state.toggles.roscore.state : 'unknown';
+            pieces.push('Roscore: ' + roscoreState);
+          }
+          if (pieces.length) {
+            setStatus(pieces.join(' • '));
+          } else {
+            setStatus('Ready');
+          }
+        }
+
+        function handleAction(action, payload) {
+          if (payload === undefined) {
+            payload = {};
+          }
+          postJSON('/api/action', { action: action, payload: payload }).catch(function (err) {
+            if (window.console && console.error) {
+              console.error(err);
+            }
+            window.alert(err && err.message ? err.message : 'Action failed');
           });
-      }
-
-      function openTabWindow(tab) {
-        const popup = window.open('', `_tab_${tab.key}`, 'width=720,height=560');
-        if (!popup) return;
-        popup.document.write(`<!DOCTYPE html><html><head><title>${tab.label}</title>` +
-          '<meta charset="utf-8" /><style>body{background:#0b0b10;color:#f8f9fa;font-family:Menlo,monospace;padding:1rem;}h1{font-size:1.2rem;margin-bottom:0.75rem;}div{line-height:1.35rem;font-size:0.9rem;} .log-line{margin-bottom:0.25rem;} .origin-gui{color:#50fa7b;}</style></head><body>' +
-          `<h1>${tab.label}</h1><div id="log-view"></div></body></html>`);
-        popup.document.close();
-        const target = popup.document.getElementById('log-view');
-        target.innerHTML = tab.logs
-          .map((line) => `<div class="log-line ${line.origin ? `origin-${line.origin}` : ''}">${line.html || ''}</div>`)
-          .join('');
-      }
-
-      function updateStatusLine() {
-        const element = document.getElementById('status-line');
-        if (!element) return;
-        const pieces = [];
-        if (state.toggles.sim) {
-          pieces.push(`Sim: ${state.toggles.sim.state || 'unknown'}`);
         }
-        if (state.toggles.roscore) {
-          pieces.push(`Roscore: ${state.toggles.roscore.state || 'unknown'}`);
+
+        function pollEvents() {
+          getJSON('/api/events?since=' + state.lastEvent)
+            .then(function (events) {
+              if (!isArray(events)) {
+                return;
+              }
+              for (var i = 0; i < events.length; i += 1) {
+                var evt = events[i];
+                if (evt && evt.id && evt.id > state.lastEvent) {
+                  state.lastEvent = evt.id;
+                }
+                applyEvent(evt);
+              }
+              renderLogs();
+              renderToggles();
+              updateStatusLine();
+            })
+            .catch(function (err) {
+              if (window.console && console.warn) {
+                console.warn('Polling failed', err);
+              }
+              setStatus('Connection lost – retrying…');
+            });
         }
-        element.textContent = pieces.length ? pieces.join(' • ') : 'Ready';
-      }
 
-      async function handleAction(action, payload = {}) {
-        try {
-          await postJSON('/api/action', { action, payload });
-        } catch (err) {
-          console.error(err);
-          alert(err.message || 'Action failed');
+        function initLayoutControls() {
+          var layoutSelect = document.getElementById('layout-select');
+          if (layoutSelect) {
+            layoutSelect.value = String(state.layoutColumns);
+            layoutSelect.onchange = function () {
+              var value = parseInt(layoutSelect.value, 10);
+              state.layoutColumns = isNaN(value) ? 1 : value;
+              renderLogs();
+            };
+          }
+          var actionsRow = document.getElementById('actions-row');
+          if (actionsRow) {
+            var buttons = actionsRow.getElementsByTagName('button');
+            for (var i = 0; i < buttons.length; i += 1) {
+              var btn = buttons[i];
+              btn.onclick = (function (actionName) {
+                return function () {
+                  handleAction(actionName);
+                };
+              })(btn.getAttribute('data-action'));
+            }
+          }
         }
-      }
 
-      async function pollEvents() {
-        try {
-          const events = await getJSON(`/api/events?since=${state.lastEvent}`);
-          events.forEach((evt) => {
-            state.lastEvent = Math.max(state.lastEvent, evt.id || 0);
-            applyEvent(evt);
-          });
-          renderLogs();
-          renderToggles();
-          updateStatusLine();
-        } catch (err) {
-          console.warn('Polling failed', err);
-          document.getElementById('status-line').textContent = 'Connection lost – retrying…';
+        function bootstrap() {
+          setStatus('Connecting...');
+          getJSON('/api/snapshot')
+            .then(function (snapshot) {
+              applySnapshot(snapshot || {});
+              initLayoutControls();
+              setStatus('Connected');
+              pollEvents();
+              setInterval(pollEvents, 1200);
+            })
+            .catch(function (err) {
+              if (window.console && console.error) {
+                console.error(err);
+              }
+              setStatus('Failed to connect');
+            });
         }
-      }
 
-      function initLayoutControls() {
-        const layoutSelect = document.getElementById('layout-select');
-        layoutSelect.value = String(state.layoutColumns);
-        layoutSelect.addEventListener('change', () => {
-          state.layoutColumns = Number(layoutSelect.value) || 1;
-          renderLogs();
-        });
-        document.querySelectorAll('#actions-row button').forEach((btn) => {
-          btn.addEventListener('click', () => handleAction(btn.dataset.action));
-        });
-      }
-
-      async function bootstrap() {
-        try {
-          const snapshot = await getJSON('/api/snapshot');
-          applySnapshot(snapshot);
-          initLayoutControls();
-          document.getElementById('status-line').textContent = 'Connected';
-          setInterval(pollEvents, 1200);
-        } catch (err) {
-          console.error(err);
-          document.getElementById('status-line').textContent = 'Failed to connect';
+        if (document.readyState === 'complete' || document.readyState === 'interactive') {
+          setTimeout(bootstrap, 0);
+        } else {
+          window.addEventListener('DOMContentLoaded', bootstrap);
         }
-      }
-
-      bootstrap();
+      })();
     </script>
   </body>
 </html>

--- a/mobipick_gui/web_assets.py
+++ b/mobipick_gui/web_assets.py
@@ -257,6 +257,165 @@ INDEX_HTML = r"""<!DOCTYPE html>
       (function () {
         'use strict';
 
+        if (typeof window.Promise !== 'function') {
+          function SimplePromise(executor) {
+            if (!(this instanceof SimplePromise)) {
+              throw new TypeError('Promise must be called with new');
+            }
+            if (typeof executor !== 'function') {
+              throw new TypeError('Promise executor must be a function');
+            }
+
+            var self = this;
+            self._state = 'pending';
+            self._value = undefined;
+            self._handlers = [];
+
+            function schedule(fn) {
+              window.setTimeout(fn, 0);
+            }
+
+            function handle(handler) {
+              var cb = self._state === 'fulfilled' ? handler.onFulfilled : handler.onRejected;
+              if (typeof cb !== 'function') {
+                if (self._state === 'fulfilled') {
+                  handler.resolve(self._value);
+                } else {
+                  handler.reject(self._value);
+                }
+                return;
+              }
+              try {
+                var result = cb(self._value);
+                handler.resolve(result);
+              } catch (err) {
+                handler.reject(err);
+              }
+            }
+
+            function runHandlers() {
+              if (self._handlers.length === 0) {
+                return;
+              }
+              var handlers = self._handlers.slice(0);
+              self._handlers.length = 0;
+              for (var i = 0; i < handlers.length; i += 1) {
+                handle(handlers[i]);
+              }
+            }
+
+            function addHandler(handler) {
+              if (self._state === 'pending') {
+                self._handlers.push(handler);
+              } else {
+                schedule(function () {
+                  handle(handler);
+                });
+              }
+            }
+
+            function settle(state, value) {
+              if (self._state !== 'pending') {
+                return;
+              }
+              self._state = state;
+              self._value = value;
+              schedule(runHandlers);
+            }
+
+            function fulfill(value) {
+              settle('fulfilled', value);
+            }
+
+            function reject(reason) {
+              settle('rejected', reason);
+            }
+
+            function resolve(value) {
+              if (value === self) {
+                reject(new TypeError('Cannot resolve promise with itself'));
+                return;
+              }
+              if (value && (typeof value === 'object' || typeof value === 'function')) {
+                var then;
+                try {
+                  then = value.then;
+                } catch (err) {
+                  reject(err);
+                  return;
+                }
+                if (typeof then === 'function') {
+                  var called = false;
+                  try {
+                    then.call(
+                      value,
+                      function (val) {
+                        if (called) {
+                          return;
+                        }
+                        called = true;
+                        resolve(val);
+                      },
+                      function (err) {
+                        if (called) {
+                          return;
+                        }
+                        called = true;
+                        reject(err);
+                      }
+                    );
+                    return;
+                  } catch (err2) {
+                    if (!called) {
+                      reject(err2);
+                    }
+                    return;
+                  }
+                }
+              }
+              fulfill(value);
+            }
+
+            this._addHandler = addHandler;
+
+            try {
+              executor(resolve, reject);
+            } catch (err3) {
+              reject(err3);
+            }
+          }
+
+          SimplePromise.prototype.then = function (onFulfilled, onRejected) {
+            var self = this;
+            return new SimplePromise(function (resolve, reject) {
+              self._addHandler({
+                onFulfilled: onFulfilled,
+                onRejected: onRejected,
+                resolve: resolve,
+                reject: reject
+              });
+            });
+          };
+
+          SimplePromise.prototype.catch = function (onRejected) {
+            return this.then(undefined, onRejected);
+          };
+
+          SimplePromise.resolve = function (value) {
+            return new SimplePromise(function (resolve) {
+              resolve(value);
+            });
+          };
+
+          SimplePromise.reject = function (reason) {
+            return new SimplePromise(function (_resolve, reject) {
+              reject(reason);
+            });
+          };
+
+          window.Promise = SimplePromise;
+        }
+
         var state = {
           toggles: {},
           tabs: {},

--- a/mobipick_gui/web_assets.py
+++ b/mobipick_gui/web_assets.py
@@ -891,10 +891,29 @@ INDEX_HTML = r"""<!DOCTYPE html>
 
         function pollEvents() {
           getJSON('/api/events?since=' + state.lastEvent)
-            .then(function (events) {
-              if (!isArray(events)) {
-                return;
+            .then(function (payload) {
+              var events = [];
+              var nextSince = null;
+              if (isArray(payload)) {
+                events = payload;
+                if (events.length) {
+                  var last = events[events.length - 1];
+                  if (last && last.id !== undefined && last.id !== null) {
+                    nextSince = parseInt(last.id, 10);
+                  }
+                }
+              } else if (payload && typeof payload === 'object') {
+                if (isArray(payload.events)) {
+                  events = payload.events;
+                }
+                if (hasOwn(payload, 'next_since')) {
+                  var parsed = parseInt(payload.next_since, 10);
+                  if (!isNaN(parsed)) {
+                    nextSince = parsed;
+                  }
+                }
               }
+
               for (var i = 0; i < events.length; i += 1) {
                 var evt = events[i];
                 if (evt && evt.id && evt.id > state.lastEvent) {
@@ -902,6 +921,13 @@ INDEX_HTML = r"""<!DOCTYPE html>
                 }
                 applyEvent(evt);
               }
+
+              if (nextSince !== null && !isNaN(nextSince)) {
+                if (state.lastEvent < nextSince) {
+                  state.lastEvent = nextSince;
+                }
+              }
+
               renderLogs();
               renderToggles();
               updateStatusLine();

--- a/mobipick_gui/web_bridge.py
+++ b/mobipick_gui/web_bridge.py
@@ -1,0 +1,243 @@
+"""Utilities for bridging GUI state into a lightweight web UI."""
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable, List, Optional
+
+from PyQt5.QtCore import QObject, pyqtSignal
+
+
+@dataclass(slots=True)
+class _TabState:
+    """State for a tab mirrored into the web interface."""
+
+    key: str
+    label: str
+    closable: bool
+    logs: List[dict[str, Any]] = field(default_factory=list)
+
+
+class NullWebBridge:
+    """Fallback bridge that performs no work when web mode is disabled."""
+
+    def attach_window(self, *_: Any, **__: Any) -> None:  # pragma: no cover - trivial
+        return
+
+    def ensure_tab(self, *_: Any, **__: Any) -> None:  # pragma: no cover - trivial
+        return
+
+    def remove_tab(self, *_: Any, **__: Any) -> None:  # pragma: no cover - trivial
+        return
+
+    def append_log(self, *_: Any, **__: Any) -> None:  # pragma: no cover - trivial
+        return
+
+    def update_toggle(self, *_: Any, **__: Any) -> None:  # pragma: no cover - trivial
+        return
+
+    def update_combobox(self, *_: Any, **__: Any) -> None:  # pragma: no cover - trivial
+        return
+
+    def record_status(self, *_: Any, **__: Any) -> None:  # pragma: no cover - trivial
+        return
+
+    def snapshot(self) -> dict[str, Any]:  # pragma: no cover - trivial
+        return {
+            "toggles": {},
+            "tabs": {},
+            "events": [],
+            "combobox": {},
+        }
+
+    def events_since(self, *_: Any, **__: Any) -> list[dict[str, Any]]:  # pragma: no cover - trivial
+        return []
+
+    def invoke(self, callback: Callable[[], Any]) -> None:  # pragma: no cover - trivial
+        callback()
+
+    def shutdown(self) -> None:  # pragma: no cover - trivial
+        return
+
+
+class WebBridge(QObject):
+    """Shares GUI state between the Qt widgets and a lightweight web client."""
+
+    invoke_signal = pyqtSignal(object)
+
+    def __init__(self, *, max_events: int = 1500, max_logs: int = 400):
+        super().__init__()
+        self._lock = threading.RLock()
+        self._toggles: dict[str, dict[str, Any]] = {}
+        self._tabs: dict[str, _TabState] = {}
+        self._events: list[dict[str, Any]] = []
+        self._max_events = max(10, int(max_events))
+        self._max_logs = max(50, int(max_logs))
+        self._next_event_id = 1
+        self._combobox: dict[str, dict[str, Any]] = {}
+        self._status: dict[str, Any] = {}
+        self._qt_thread_id = threading.get_ident()
+        self.invoke_signal.connect(self._dispatch_invocation)
+
+    # ------------------------------------------------------------------
+    # Invocation helpers
+    # ------------------------------------------------------------------
+    def attach_window(self, window: QObject) -> None:
+        """Ensure the bridge lives on the same thread as the Qt window."""
+
+        if window.thread() is not None and window.thread() is not self.thread():
+            self.moveToThread(window.thread())
+
+    def _dispatch_invocation(self, callback: Callable[[], Any]) -> None:
+        try:
+            callback()
+        except Exception:
+            # We intentionally swallow exceptions here; they will surface
+            # through the GUI logging path instead.
+            pass
+
+    def invoke(self, callback: Callable[[], Any]) -> None:
+        """Schedule *callback* to run on the Qt GUI thread."""
+
+        if threading.get_ident() == self._qt_thread_id:
+            callback()
+            return
+        self.invoke_signal.emit(callback)
+
+    # ------------------------------------------------------------------
+    # Event and snapshot bookkeeping
+    # ------------------------------------------------------------------
+    def _publish_event(self, event_type: str, payload: dict[str, Any]) -> None:
+        with self._lock:
+            event = {
+                "id": self._next_event_id,
+                "type": event_type,
+                "payload": payload,
+                "ts": time.time(),
+            }
+            self._next_event_id += 1
+            self._events.append(event)
+            if len(self._events) > self._max_events:
+                self._events = self._events[-self._max_events :]
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return a snapshot of the mirrored state."""
+
+        with self._lock:
+            return {
+                "toggles": dict(self._toggles),
+                "tabs": {k: {
+                    "key": v.key,
+                    "label": v.label,
+                    "closable": v.closable,
+                    "logs": list(v.logs),
+                } for k, v in self._tabs.items()},
+                "events": list(self._events[-50:]),
+                "combobox": dict(self._combobox),
+                "status": dict(self._status),
+            }
+
+    def events_since(self, event_id: int) -> list[dict[str, Any]]:
+        with self._lock:
+            if not self._events:
+                return []
+            if event_id <= 0:
+                return list(self._events)
+            return [evt for evt in self._events if evt["id"] > event_id]
+
+    # ------------------------------------------------------------------
+    # GUI -> web updates
+    # ------------------------------------------------------------------
+    def ensure_tab(self, key: str, label: str, closable: bool) -> None:
+        with self._lock:
+            if key in self._tabs:
+                tab_state = self._tabs[key]
+                changed = tab_state.label != label or tab_state.closable != closable
+                tab_state.label = label
+                tab_state.closable = closable
+            else:
+                tab_state = _TabState(key=key, label=label, closable=closable)
+                self._tabs[key] = tab_state
+                changed = True
+        if changed:
+            self._publish_event("tab", {"key": key, "label": label, "closable": closable})
+
+    def remove_tab(self, key: str) -> None:
+        removed = False
+        with self._lock:
+            if key in self._tabs:
+                del self._tabs[key]
+                removed = True
+        if removed:
+            self._publish_event("tab_removed", {"key": key})
+
+    def append_log(self, key: str, html_text: str, *, origin: str) -> None:
+        log_item = {
+            "html": html_text,
+            "origin": origin,
+            "ts": time.time(),
+        }
+        with self._lock:
+            tab = self._tabs.setdefault(key, _TabState(key=key, label=key, closable=True))
+            tab.logs.append(log_item)
+            if len(tab.logs) > self._max_logs:
+                tab.logs = tab.logs[-self._max_logs :]
+        self._publish_event("log", {"key": key, **log_item})
+
+    def update_toggle(
+        self,
+        key: str,
+        *,
+        state: str,
+        text: str,
+        enabled: bool,
+        colors: dict[str, str],
+    ) -> None:
+        with self._lock:
+            self._toggles[key] = {
+                "state": state,
+                "text": text,
+                "enabled": enabled,
+                "colors": dict(colors),
+            }
+        self._publish_event("toggle", {"key": key, **self._toggles[key]})
+
+    def update_combobox(
+        self,
+        name: str,
+        *,
+        options: Iterable[str],
+        current: Optional[str],
+    ) -> None:
+        with self._lock:
+            self._combobox[name] = {
+                "options": list(options),
+                "current": current,
+            }
+        self._publish_event(
+            "combobox",
+            {"name": name, "options": list(options), "current": current},
+        )
+
+    def record_status(self, key: str, value: Any) -> None:
+        with self._lock:
+            self._status[key] = value
+        self._publish_event("status", {"key": key, "value": value})
+
+    # ------------------------------------------------------------------
+    # Shutdown helpers
+    # ------------------------------------------------------------------
+    def shutdown(self) -> None:
+        with self._lock:
+            self._events.append({
+                "id": self._next_event_id,
+                "type": "shutdown",
+                "payload": {},
+                "ts": time.time(),
+            })
+            self._next_event_id += 1
+
+
+__all__ = ["WebBridge", "NullWebBridge"]
+

--- a/mobipick_gui/web_bridge.py
+++ b/mobipick_gui/web_bridge.py
@@ -55,8 +55,8 @@ class NullWebBridge:
             "combobox": {},
         }
 
-    def events_since(self, *_: Any, **__: Any) -> list[dict[str, Any]]:  # pragma: no cover - trivial
-        return []
+    def events_since(self, *_: Any, **__: Any) -> dict[str, Any]:  # pragma: no cover - trivial
+        return {"events": [], "next_since": 0}
 
     def invoke(self, callback: Callable[[], Any]) -> None:  # pragma: no cover - trivial
         callback()
@@ -147,15 +147,24 @@ class WebBridge(QObject):
                 "status": dict(self._status),
             }
 
-    def events_since(self, event_id: int) -> list[dict[str, Any]]:
+    def events_since(self, event_id: int) -> dict[str, Any]:
         with self._lock:
             if not self._events:
-                return []
+                logger.debug('events_since(%d) -> empty (no events recorded)', event_id)
+                return {"events": [], "next_since": max(0, event_id)}
+
             if event_id <= 0:
-                return list(self._events)
-            events = [evt for evt in self._events if evt["id"] > event_id]
-        logger.debug('events_since(%d) -> %d events', event_id, len(events))
-        return events
+                events = list(self._events)
+            else:
+                events = [evt for evt in self._events if evt["id"] > event_id]
+
+            if events:
+                next_since = events[-1]["id"]
+            else:
+                next_since = max(event_id, self._events[-1]["id"])
+
+        logger.debug('events_since(%d) -> %d events (next_since=%d)', event_id, len(events), next_since)
+        return {"events": events, "next_since": next_since}
 
     # ------------------------------------------------------------------
     # GUI -> web updates

--- a/mobipick_gui/web_bridge.py
+++ b/mobipick_gui/web_bridge.py
@@ -8,6 +8,10 @@ from typing import Any, Callable, Iterable, List, Optional
 
 from PyQt5.QtCore import QObject, pyqtSignal
 
+from .logging_utils import get_logger
+
+
+logger = get_logger(__name__)
 
 @dataclass(slots=True)
 class _TabState:
@@ -79,6 +83,7 @@ class WebBridge(QObject):
         self._status: dict[str, Any] = {}
         self._qt_thread_id = threading.get_ident()
         self.invoke_signal.connect(self._dispatch_invocation)
+        logger.debug('WebBridge initialized (max_events=%d, max_logs=%d)', self._max_events, self._max_logs)
 
     # ------------------------------------------------------------------
     # Invocation helpers
@@ -88,6 +93,7 @@ class WebBridge(QObject):
 
         if window.thread() is not None and window.thread() is not self.thread():
             self.moveToThread(window.thread())
+            logger.debug('WebBridge moved to GUI thread %s', window.thread())
 
     def _dispatch_invocation(self, callback: Callable[[], Any]) -> None:
         try:
@@ -95,7 +101,7 @@ class WebBridge(QObject):
         except Exception:
             # We intentionally swallow exceptions here; they will surface
             # through the GUI logging path instead.
-            pass
+            logger.exception('Exception occurred during bridge invocation')
 
     def invoke(self, callback: Callable[[], Any]) -> None:
         """Schedule *callback* to run on the Qt GUI thread."""
@@ -103,6 +109,7 @@ class WebBridge(QObject):
         if threading.get_ident() == self._qt_thread_id:
             callback()
             return
+        logger.debug('Scheduling callback on GUI thread (qt_thread_id=%s)', self._qt_thread_id)
         self.invoke_signal.emit(callback)
 
     # ------------------------------------------------------------------
@@ -120,11 +127,13 @@ class WebBridge(QObject):
             self._events.append(event)
             if len(self._events) > self._max_events:
                 self._events = self._events[-self._max_events :]
+        logger.debug('Published event %s #%d', event_type, event["id"])
 
     def snapshot(self) -> dict[str, Any]:
         """Return a snapshot of the mirrored state."""
 
         with self._lock:
+            logger.debug('Snapshot requested; %d tabs cached, %d events stored', len(self._tabs), len(self._events))
             return {
                 "toggles": dict(self._toggles),
                 "tabs": {k: {
@@ -144,7 +153,9 @@ class WebBridge(QObject):
                 return []
             if event_id <= 0:
                 return list(self._events)
-            return [evt for evt in self._events if evt["id"] > event_id]
+            events = [evt for evt in self._events if evt["id"] > event_id]
+        logger.debug('events_since(%d) -> %d events', event_id, len(events))
+        return events
 
     # ------------------------------------------------------------------
     # GUI -> web updates
@@ -162,6 +173,7 @@ class WebBridge(QObject):
                 changed = True
         if changed:
             self._publish_event("tab", {"key": key, "label": label, "closable": closable})
+            logger.debug('ensure_tab updated %s (label=%s closable=%s)', key, label, closable)
 
     def remove_tab(self, key: str) -> None:
         removed = False
@@ -171,6 +183,7 @@ class WebBridge(QObject):
                 removed = True
         if removed:
             self._publish_event("tab_removed", {"key": key})
+            logger.debug('Removed tab %s', key)
 
     def append_log(self, key: str, html_text: str, *, origin: str) -> None:
         log_item = {
@@ -184,6 +197,7 @@ class WebBridge(QObject):
             if len(tab.logs) > self._max_logs:
                 tab.logs = tab.logs[-self._max_logs :]
         self._publish_event("log", {"key": key, **log_item})
+        logger.debug('Appended log for tab %s (origin=%s)', key, origin)
 
     def update_toggle(
         self,
@@ -202,6 +216,7 @@ class WebBridge(QObject):
                 "colors": dict(colors),
             }
         self._publish_event("toggle", {"key": key, **self._toggles[key]})
+        logger.debug('Toggle %s updated -> %s', key, state)
 
     def update_combobox(
         self,
@@ -219,11 +234,13 @@ class WebBridge(QObject):
             "combobox",
             {"name": name, "options": list(options), "current": current},
         )
+        logger.debug('Combobox %s updated (current=%s)', name, current)
 
     def record_status(self, key: str, value: Any) -> None:
         with self._lock:
             self._status[key] = value
         self._publish_event("status", {"key": key, "value": value})
+        logger.debug('Status %s recorded -> %s', key, value)
 
     # ------------------------------------------------------------------
     # Shutdown helpers
@@ -237,6 +254,7 @@ class WebBridge(QObject):
                 "ts": time.time(),
             })
             self._next_event_id += 1
+        logger.debug('WebBridge shutdown event recorded')
 
 
 __all__ = ["WebBridge", "NullWebBridge"]

--- a/mobipick_gui/web_controller.py
+++ b/mobipick_gui/web_controller.py
@@ -1,0 +1,166 @@
+"""Action dispatcher used by the web UI server."""
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from .main_window import MainWindow
+from .web_bridge import WebBridge
+
+
+class WebController:
+    """Dispatches actions from the web UI into the Qt GUI thread."""
+
+    def __init__(self, window: MainWindow, bridge: WebBridge):
+        self._window = window
+        self._bridge = bridge
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def handle(self, action: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+        payload = payload or {}
+        handlers: dict[str, Callable[[dict[str, Any]], dict[str, Any]]] = {
+            'toggle_roscore': self._toggle_roscore,
+            'toggle_sim': self._toggle_sim,
+            'toggle_tables': self._toggle_tables,
+            'toggle_rviz': self._toggle_rviz,
+            'toggle_rqt': self._toggle_rqt,
+            'toggle_terminal': self._toggle_terminal,
+            'toggle_script': self._toggle_script,
+            'refresh_status': self._refresh_status,
+            'refresh_images': self._refresh_images,
+            'refresh_scripts': self._refresh_scripts,
+            'set_combo': self._set_combo,
+            'invoke_custom': self._invoke_custom,
+        }
+        handler = handlers.get(action)
+        if handler is None:
+            raise ValueError(f'Unknown action: {action}')
+        return handler(payload)
+
+    # ------------------------------------------------------------------
+    # Action handlers
+    # ------------------------------------------------------------------
+    def _guard_busy(self, key: str) -> bool:
+        state = self._window._toggle_states.get(key)
+        if state == 'yellow':
+            self._window._append_gui_html('log', f'<i>{key} is busy, please wait...</i>')
+            return False
+        return True
+
+    def _toggle_roscore(self, _payload: dict[str, Any]) -> dict[str, Any]:
+        def _do():
+            if not self._guard_busy('roscore'):
+                return
+            self._window._log_event('web toggled roscore')
+            self._window.toggle_roscore()
+
+        self._bridge.invoke(_do)
+        return {'ok': True}
+
+    def _toggle_sim(self, _payload: dict[str, Any]) -> dict[str, Any]:
+        def _do():
+            if not self._guard_busy('sim'):
+                return
+            self._window._log_event('web toggled sim')
+            self._window.toggle_sim()
+
+        self._bridge.invoke(_do)
+        return {'ok': True}
+
+    def _toggle_tables(self, _payload: dict[str, Any]) -> dict[str, Any]:
+        def _do():
+            if not self._guard_busy('tables'):
+                return
+            self._window._log_event('web toggled tables demo')
+            self._window.toggle_tables_demo()
+
+        self._bridge.invoke(_do)
+        return {'ok': True}
+
+    def _toggle_rviz(self, _payload: dict[str, Any]) -> dict[str, Any]:
+        def _do():
+            if not self._guard_busy('rviz'):
+                return
+            self._window._log_event('web toggled rviz')
+            self._window.toggle_rviz()
+
+        self._bridge.invoke(_do)
+        return {'ok': True}
+
+    def _toggle_rqt(self, _payload: dict[str, Any]) -> dict[str, Any]:
+        def _do():
+            if not self._guard_busy('rqt'):
+                return
+            self._window._log_event('web toggled rqt tables')
+            self._window.toggle_rqt_tables_demo()
+
+        self._bridge.invoke(_do)
+        return {'ok': True}
+
+    def _toggle_terminal(self, _payload: dict[str, Any]) -> dict[str, Any]:
+        def _do():
+            if not self._guard_busy('terminal'):
+                return
+            self._window._log_event('web toggled terminal')
+            self._window.toggle_terminal()
+
+        self._bridge.invoke(_do)
+        return {'ok': True}
+
+    def _toggle_script(self, _payload: dict[str, Any]) -> dict[str, Any]:
+        def _do():
+            if not self._guard_busy('script'):
+                return
+            self._window._log_event('web toggled script execution')
+            self._window.toggle_script_execution()
+
+        self._bridge.invoke(_do)
+        return {'ok': True}
+
+    def _refresh_status(self, _payload: dict[str, Any]) -> dict[str, Any]:
+        self._bridge.invoke(lambda: self._window.update_sim_status_from_poll(force=True))
+        return {'ok': True}
+
+    def _refresh_images(self, _payload: dict[str, Any]) -> dict[str, Any]:
+        self._bridge.invoke(self._window._reload_images)
+        return {'ok': True}
+
+    def _refresh_scripts(self, _payload: dict[str, Any]) -> dict[str, Any]:
+        self._bridge.invoke(self._window._on_refresh_scripts_clicked)
+        return {'ok': True}
+
+    def _set_combo(self, payload: dict[str, Any]) -> dict[str, Any]:
+        name = payload.get('name')
+        value = payload.get('value')
+        if not name:
+            raise ValueError('Missing combo name')
+
+        def _do():
+            combo = getattr(self._window, f'{name}_combo', None)
+            if combo is None:
+                raise ValueError(f'Unknown combo: {name}')
+            index = combo.findText(str(value)) if value is not None else -1
+            if index < 0:
+                self._window._append_gui_html('log', f'<i>{name} option {value!r} not available.</i>')
+                return
+            combo.setCurrentIndex(index)
+
+        self._bridge.invoke(_do)
+        return {'ok': True}
+
+    def _invoke_custom(self, payload: dict[str, Any]) -> dict[str, Any]:
+        target = payload.get('target')
+        if not target or not hasattr(self._window, target):
+            raise ValueError('Invalid custom target')
+        func = getattr(self._window, target)
+        if not callable(func):
+            raise ValueError('Target is not callable')
+        args = payload.get('args') or []
+        kwargs = payload.get('kwargs') or {}
+        self._bridge.invoke(lambda: func(*args, **kwargs))
+        return {'ok': True}
+
+
+__all__ = ["WebController"]
+

--- a/mobipick_gui/web_controller.py
+++ b/mobipick_gui/web_controller.py
@@ -5,6 +5,10 @@ from typing import Any, Callable
 
 from .main_window import MainWindow
 from .web_bridge import WebBridge
+from .logging_utils import get_logger
+
+
+logger = get_logger(__name__)
 
 
 class WebController:
@@ -13,6 +17,7 @@ class WebController:
     def __init__(self, window: MainWindow, bridge: WebBridge):
         self._window = window
         self._bridge = bridge
+        logger.debug('WebController initialized with window=%s', window)
 
     # ------------------------------------------------------------------
     # Public API
@@ -36,7 +41,10 @@ class WebController:
         handler = handlers.get(action)
         if handler is None:
             raise ValueError(f'Unknown action: {action}')
-        return handler(payload)
+        logger.debug('Handling action %s with payload keys %s', action, list(payload.keys()))
+        result = handler(payload)
+        logger.debug('Action %s result: %s', action, result)
+        return result
 
     # ------------------------------------------------------------------
     # Action handlers
@@ -45,6 +53,7 @@ class WebController:
         state = self._window._toggle_states.get(key)
         if state == 'yellow':
             self._window._append_gui_html('log', f'<i>{key} is busy, please wait...</i>')
+            logger.debug('Guard prevented action for %s because state is %s', key, state)
             return False
         return True
 

--- a/mobipick_gui/web_server.py
+++ b/mobipick_gui/web_server.py
@@ -14,6 +14,10 @@ from urllib.parse import parse_qs, urlparse
 from .web_assets import INDEX_HTML
 from .web_bridge import WebBridge
 from .web_controller import WebController
+from .logging_utils import get_logger
+
+
+logger = get_logger(__name__)
 
 
 class _ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
@@ -35,6 +39,7 @@ class _RequestHandler(BaseHTTPRequestHandler):
         return
 
     def _write_response(self, status: HTTPStatus, body: bytes, content_type: str = 'application/json') -> None:
+        logger.debug('Responding %s to %s %s', status.value, self.command, self.path)
         self.send_response(status)
         self.send_header('Content-Type', content_type)
         self.send_header('Content-Length', str(len(body)))
@@ -64,18 +69,21 @@ class _RequestHandler(BaseHTTPRequestHandler):
         return getattr(self.server, 'controller')  # type: ignore[no-any-return]
 
     def do_GET(self) -> None:  # noqa: N802 - required signature
+        logger.debug('Handling GET %s', self.path)
         parsed = urlparse(self.path)
         if parsed.path in {'/', '/index.html'}:
             self._write_response(HTTPStatus.OK, INDEX_HTML.encode('utf-8'), 'text/html; charset=utf-8')
             return
         if parsed.path == '/api/snapshot':
             snapshot = self.bridge.snapshot()
+            logger.debug('Snapshot includes %d tabs, %d toggles, %d events', len(snapshot['tabs']), len(snapshot['toggles']), len(snapshot['events']))
             self._json(snapshot)
             return
         if parsed.path == '/api/events':
             query = parse_qs(parsed.query)
             since = int(query.get('since', ['0'])[0] or 0)
             events = self.bridge.events_since(since)
+            logger.debug('Returning %d events since id %d', len(events), since)
             self._json(events)
             return
         if parsed.path == '/api/health':
@@ -84,6 +92,7 @@ class _RequestHandler(BaseHTTPRequestHandler):
         self._write_response(HTTPStatus.NOT_FOUND, b'Not Found', 'text/plain; charset=utf-8')
 
     def do_POST(self) -> None:  # noqa: N802 - required signature
+        logger.debug('Handling POST %s', self.path)
         parsed = urlparse(self.path)
         if parsed.path != '/api/action':
             self._write_response(HTTPStatus.NOT_FOUND, b'Not Found', 'text/plain; charset=utf-8')
@@ -91,27 +100,33 @@ class _RequestHandler(BaseHTTPRequestHandler):
         try:
             length = int(self.headers.get('Content-Length', '0'))
         except ValueError:
+            logger.warning('Invalid Content-Length header: %s', self.headers.get('Content-Length'))
             self._bad_request('Invalid Content-Length header')
             return
         raw = self.rfile.read(length) if length > 0 else b''
         try:
             data = json.loads(raw.decode('utf-8') or '{}')
         except json.JSONDecodeError:
+            logger.warning('Failed to decode JSON payload: %s', raw)
             self._bad_request('Invalid JSON payload')
             return
         action = data.get('action')
         payload = data.get('payload') or {}
         if not isinstance(payload, dict):
+            logger.warning('Invalid payload type for action %s: %r', action, type(payload))
             self._bad_request('Payload must be an object')
             return
         if not isinstance(action, str) or not action:
+            logger.warning('Missing action in request: %s', data)
             self._bad_request('Action is required')
             return
         try:
             result = self.controller.handle(action, payload)
         except Exception as exc:  # noqa: BLE001 - propagate to caller
+            logger.exception('Controller error while handling action %s', action)
             self._json({'error': str(exc)}, HTTPStatus.BAD_REQUEST)
             return
+        logger.debug('Action %s completed with result keys %s', action, list(result.keys()))
         self._json(result)
 
 
@@ -138,30 +153,37 @@ class WebUiServer:
 
     def start(self) -> None:
         if self._server is not None:
+            logger.debug('WebUiServer already running at %s', self.address)
             return
 
         def _serve():
+            logger.debug('WebUiServer serving loop entering on %s:%s', self._host, self._port)
             with _ThreadingHTTPServer((self._host, self._port), _RequestHandler, bridge=self._bridge, controller=self._controller) as server:
                 self._server = server
                 self._ready.set()
                 try:
                     server.serve_forever()
                 finally:
+                    logger.debug('WebUiServer serve_forever exited')
                     self._server = None
 
         self._thread = threading.Thread(target=_serve, name='web-ui-server', daemon=True)
         self._thread.start()
         self._ready.wait(timeout=5)
+        logger.debug('WebUiServer thread started; address=%s', self.address)
 
     def stop(self) -> None:
         server = self._server
         if server is None:
+            logger.debug('WebUiServer stop requested but server already stopped')
             return
+        logger.debug('Shutting down WebUiServer at %s', self.address)
         server.shutdown()
         server.server_close()
         self._server = None
         if self._thread and self._thread.is_alive():
             self._thread.join(timeout=2)
+        logger.debug('WebUiServer thread stopped')
         self._thread = None
 
 

--- a/mobipick_gui/web_server.py
+++ b/mobipick_gui/web_server.py
@@ -43,7 +43,10 @@ class _RequestHandler(BaseHTTPRequestHandler):
         self.send_response(status)
         self.send_header('Content-Type', content_type)
         self.send_header('Content-Length', str(len(body)))
-        self.send_header('Cache-Control', 'no-store')
+        self.send_header('Cache-Control', 'no-store, no-cache, must-revalidate')
+        self.send_header('Pragma', 'no-cache')
+        self.send_header('Expires', '0')
+        self.send_header('X-Accel-Buffering', 'no')
         self.send_header('Connection', 'close')
         self.end_headers()
         if body:
@@ -82,9 +85,10 @@ class _RequestHandler(BaseHTTPRequestHandler):
         if parsed.path == '/api/events':
             query = parse_qs(parsed.query)
             since = int(query.get('since', ['0'])[0] or 0)
-            events = self.bridge.events_since(since)
-            logger.debug('Returning %d events since id %d', len(events), since)
-            self._json(events)
+            payload = self.bridge.events_since(since)
+            events = payload.get('events', []) if isinstance(payload, dict) else []
+            logger.debug('Returning %d events since id %d (next_since=%s)', len(events), since, payload.get('next_since') if isinstance(payload, dict) else 'n/a')
+            self._json(payload)
             return
         if parsed.path == '/api/health':
             self._json({'ok': True, 'ts': time.time()})

--- a/mobipick_gui/web_server.py
+++ b/mobipick_gui/web_server.py
@@ -1,0 +1,175 @@
+"""Minimal HTTP server exposing the GUI through a browser-friendly interface."""
+from __future__ import annotations
+
+import json
+import socket
+import threading
+import time
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from socketserver import ThreadingMixIn
+from typing import Any, Callable
+from urllib.parse import parse_qs, urlparse
+
+from .web_assets import INDEX_HTML
+from .web_bridge import WebBridge
+from .web_controller import WebController
+
+
+class _ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
+    """HTTP server that tracks connections and exposes bridge/controller."""
+
+    daemon_threads = True
+    allow_reuse_address = True
+
+    def __init__(self, server_address, RequestHandlerClass, *, bridge: WebBridge, controller: WebController):
+        super().__init__(server_address, RequestHandlerClass)
+        self.bridge = bridge
+        self.controller = controller
+
+
+class _RequestHandler(BaseHTTPRequestHandler):
+    protocol_version = 'HTTP/1.1'
+
+    def log_message(self, format: str, *args: Any) -> None:  # pragma: no cover - reduce noise
+        return
+
+    def _write_response(self, status: HTTPStatus, body: bytes, content_type: str = 'application/json') -> None:
+        self.send_response(status)
+        self.send_header('Content-Type', content_type)
+        self.send_header('Content-Length', str(len(body)))
+        self.send_header('Cache-Control', 'no-store')
+        self.send_header('Connection', 'close')
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+            try:
+                self.wfile.flush()
+            except Exception:  # pragma: no cover - best effort flush
+                pass
+
+    def _json(self, obj: Any, status: HTTPStatus = HTTPStatus.OK) -> None:
+        body = json.dumps(obj).encode('utf-8')
+        self._write_response(status, body, 'application/json')
+
+    def _bad_request(self, message: str) -> None:
+        self._json({'error': message}, HTTPStatus.BAD_REQUEST)
+
+    @property
+    def bridge(self) -> WebBridge:
+        return getattr(self.server, 'bridge')  # type: ignore[no-any-return]
+
+    @property
+    def controller(self) -> WebController:
+        return getattr(self.server, 'controller')  # type: ignore[no-any-return]
+
+    def do_GET(self) -> None:  # noqa: N802 - required signature
+        parsed = urlparse(self.path)
+        if parsed.path in {'/', '/index.html'}:
+            self._write_response(HTTPStatus.OK, INDEX_HTML.encode('utf-8'), 'text/html; charset=utf-8')
+            return
+        if parsed.path == '/api/snapshot':
+            snapshot = self.bridge.snapshot()
+            self._json(snapshot)
+            return
+        if parsed.path == '/api/events':
+            query = parse_qs(parsed.query)
+            since = int(query.get('since', ['0'])[0] or 0)
+            events = self.bridge.events_since(since)
+            self._json(events)
+            return
+        if parsed.path == '/api/health':
+            self._json({'ok': True, 'ts': time.time()})
+            return
+        self._write_response(HTTPStatus.NOT_FOUND, b'Not Found', 'text/plain; charset=utf-8')
+
+    def do_POST(self) -> None:  # noqa: N802 - required signature
+        parsed = urlparse(self.path)
+        if parsed.path != '/api/action':
+            self._write_response(HTTPStatus.NOT_FOUND, b'Not Found', 'text/plain; charset=utf-8')
+            return
+        try:
+            length = int(self.headers.get('Content-Length', '0'))
+        except ValueError:
+            self._bad_request('Invalid Content-Length header')
+            return
+        raw = self.rfile.read(length) if length > 0 else b''
+        try:
+            data = json.loads(raw.decode('utf-8') or '{}')
+        except json.JSONDecodeError:
+            self._bad_request('Invalid JSON payload')
+            return
+        action = data.get('action')
+        payload = data.get('payload') or {}
+        if not isinstance(payload, dict):
+            self._bad_request('Payload must be an object')
+            return
+        if not isinstance(action, str) or not action:
+            self._bad_request('Action is required')
+            return
+        try:
+            result = self.controller.handle(action, payload)
+        except Exception as exc:  # noqa: BLE001 - propagate to caller
+            self._json({'error': str(exc)}, HTTPStatus.BAD_REQUEST)
+            return
+        self._json(result)
+
+
+class WebUiServer:
+    """Wraps the HTTP server in a background thread."""
+
+    def __init__(self, bridge: WebBridge, controller: WebController, host: str = '127.0.0.1', port: int = 0):
+        self._bridge = bridge
+        self._controller = controller
+        self._host = host
+        self._port = port
+        self._server: _ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        self._ready = threading.Event()
+
+    @property
+    def address(self) -> tuple[str, int] | None:
+        if self._server is None:
+            return None
+        host, port = self._server.server_address
+        if isinstance(host, str):
+            return host, int(port)
+        return '127.0.0.1', int(port)
+
+    def start(self) -> None:
+        if self._server is not None:
+            return
+
+        def _serve():
+            with _ThreadingHTTPServer((self._host, self._port), _RequestHandler, bridge=self._bridge, controller=self._controller) as server:
+                self._server = server
+                self._ready.set()
+                try:
+                    server.serve_forever()
+                finally:
+                    self._server = None
+
+        self._thread = threading.Thread(target=_serve, name='web-ui-server', daemon=True)
+        self._thread.start()
+        self._ready.wait(timeout=5)
+
+    def stop(self) -> None:
+        server = self._server
+        if server is None:
+            return
+        server.shutdown()
+        server.server_close()
+        self._server = None
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=2)
+        self._thread = None
+
+
+def find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('127.0.0.1', 0))
+        return int(s.getsockname()[1])
+
+
+__all__ = ["WebUiServer", "find_free_port"]
+


### PR DESCRIPTION
## Summary
- add a web bridge/server/controller layer to mirror Qt process tabs, toggles, and combos into browser-friendly events
- extend the CLI with a --web mode that launches the background HTTP server and prints the dashboard URL
- document the browser workflow and allow arranging/popping out embedded process panes from the new dashboard
- flush HTTP responses and enable threaded serving so the browser can finish connecting to the dashboard

## Testing
- python -m py_compile $(git ls-files '*.py')

------
https://chatgpt.com/codex/tasks/task_e_68e7b36d68b883319cf5aec7325604f4