### PR TITLE
Use unique container scripts directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix:ro  # for Gazebo GUI
       - /run/user:/run/user:ro  # for Gazebo GUI
-      - ./scripts:/root/scripts:rw
+      - ./scripts:/root/scripts_430ofkjl04fsw:rw
     expose:
       - 11311 # roscore
       - 12345 # gzserver
@@ -47,7 +47,7 @@ services:
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix:ro  # for gazebo gui
       - /run/user:/run/user:ro  # for Gazebo GUI
-      - ./scripts:/root/scripts:rw
+      - ./scripts:/root/scripts_430ofkjl04fsw:rw
     privileged: true  # for Gazebo GUI
 
 networks:

--- a/mobipick_gui/main_window.py
+++ b/mobipick_gui/main_window.py
@@ -36,6 +36,8 @@ from PyQt5.QtWidgets import (
 
 from .ansi import CSI_SEQ_RE, OSC_SEQ_RE, ansi_to_html
 from .config import CONFIG, DEFAULT_YAML_PATH, PROJECT_ROOT, SCRIPT_CLEAN
+
+CONTAINER_SCRIPTS_DIR = '/root/scripts_430ofkjl04fsw'
 from .process_tab import ProcessTab
 
 _SIGINT_TRIGGERED = False
@@ -687,7 +689,7 @@ class MainWindow(QMainWindow):
             exec_id = uuid.uuid4().hex
             tab.exec_id = exec_id
             tab.container_name = f'mpcmd-{exec_id[:10]}'
-            inner = f"python3 /root/scripts/{self._sh_quote(script)}"
+            inner = f"python3 {CONTAINER_SCRIPTS_DIR}/{self._sh_quote(script)}"
             args = [
                 'compose', 'run', '--rm', '--name', tab.container_name,
                 '--label', f'mobipick.exec={exec_id}', '--label', f'mobipick.tab={key_target}',


### PR DESCRIPTION
## Summary
- change the docker compose volume mount to use a uniquely named scripts directory inside the container
- update the GUI command execution to reference the new container scripts directory constant

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e8e36af4f883319ba9e7ccd9aa3ba4