### PR TITLE
Add configurable container bashrc sourcing

### DIFF
--- a/config/gui_settings.yaml
+++ b/config/gui_settings.yaml
@@ -39,6 +39,9 @@ process:
   compose_run_env:
     PYTHONUNBUFFERED: "1"                     # exported into docker compose runs to force unbuffered stdout
     PYTHONIOENCODING: "UTF-8"                 # ensure python subprocesses emit UTF-8
+  container_bashrc:
+    enable: true                              # when true, source the configured bashrc inside containers before commands
+    path: "/root/.bashrc"                     # path to the bashrc file to source within launched containers
 
 images:
   default: "brean/mobipick_labs:noetic"       # image:tag selected by default when the GUI starts

--- a/config/gui_settings.yaml
+++ b/config/gui_settings.yaml
@@ -5,6 +5,7 @@ log:
   text_color: "#ffffff"         # default text color for plain log lines
   gui_log_color: "#ff00ff"      # color for GUI-generated status messages
   command_log_color: "#4da3ff"  # color for command lines emitted by the GUI
+  env_log_color: "#d2b48c"      # color for optional environment dumps shown in process tabs
   font_family: "monospace"      # font family used for log text
   scroll_tolerance_min: 2       # how close (in scroll units) the user must be to the bottom for auto-scroll to stay enabled
 
@@ -39,6 +40,7 @@ process:
   compose_run_env:
     PYTHONUNBUFFERED: "1"                     # exported into docker compose runs to force unbuffered stdout
     PYTHONIOENCODING: "UTF-8"                 # ensure python subprocesses emit UTF-8
+  log_environment: false                      # when true, show the resolved environment for each container before it starts
   container_bashrc:
     enable: true                              # when true, source the configured bashrc inside containers before commands
     path: "/root/.bashrc"                     # path to the bashrc file to source within launched containers

--- a/mobipick_gui/config.py
+++ b/mobipick_gui/config.py
@@ -22,6 +22,7 @@ CONFIG_DEFAULTS: Dict[str, Dict] = {
         'text_color': '#ffffff',
         'gui_log_color': '#ff00ff',
         'command_log_color': '#4da3ff',
+        'env_log_color': '#d2b48c',
         'font_family': 'monospace',
         'scroll_tolerance_min': 2,
     },
@@ -62,6 +63,7 @@ CONFIG_DEFAULTS: Dict[str, Dict] = {
             'PYTHONUNBUFFERED': '1',
             'PYTHONIOENCODING': 'UTF-8',
         },
+        'log_environment': False,
         'container_bashrc': {
             'enable': True,
             'path': '/root/.bashrc',

--- a/mobipick_gui/config.py
+++ b/mobipick_gui/config.py
@@ -62,6 +62,10 @@ CONFIG_DEFAULTS: Dict[str, Dict] = {
             'PYTHONUNBUFFERED': '1',
             'PYTHONIOENCODING': 'UTF-8',
         },
+        'container_bashrc': {
+            'enable': True,
+            'path': '/root/.bashrc',
+        },
     },
     'exit': {
         'dialog_title': 'Shutting Down',

--- a/mobipick_gui/main_window.py
+++ b/mobipick_gui/main_window.py
@@ -101,6 +101,12 @@ class MainWindow(QMainWindow):
         self._terminal_stream_tab_key: str | None = None
         self._terminal_stream_counter = 0
         self._project_root = PROJECT_ROOT
+        process_cfg = CONFIG.get('process', {}) or {}
+        self._container_bashrc_cfg = process_cfg.get('container_bashrc', {}) or {}
+        path_value = self._container_bashrc_cfg.get('path', '')
+        self._container_bashrc_path = path_value.strip() if isinstance(path_value, str) else ''
+        enable_value = self._container_bashrc_cfg.get('enable', True)
+        self._container_bashrc_enabled = bool(enable_value) and bool(self._container_bashrc_path)
         self._docker_cp_config = load_docker_cp_config()
         self._synced_container_refs: set[str] = set()
         self._toggle_states: dict[str, str] = {}
@@ -1859,12 +1865,16 @@ class MainWindow(QMainWindow):
     def _wrap_line_buffered(self, inner: str) -> str:
         # ensure unbuffered python, utf8, and force line buffered stdout and stderr when available
         # no TTY required
+        command = inner
+        if self._container_bashrc_enabled and self._container_bashrc_path:
+            quoted = self._sh_quote(self._container_bashrc_path)
+            command = f'if [ -f {quoted} ]; then source {quoted}; fi; {command}'
         return (
             'export PYTHONUNBUFFERED=1 PYTHONIOENCODING=UTF-8; '
             'if command -v stdbuf >/dev/null 2>&1; then '
-            f'stdbuf -oL -eL {inner}; '
+            f'stdbuf -oL -eL {command}; '
             'else '
-            f'{inner}; '
+            f'{command}; '
             'fi'
         )
 

--- a/mobipick_gui/main_window.py
+++ b/mobipick_gui/main_window.py
@@ -1866,11 +1866,13 @@ class MainWindow(QMainWindow):
         # ensure unbuffered python, utf8, and force line buffered stdout and stderr when available
         # no TTY required
         command = inner
+        bashrc_prefix = ''
         if self._container_bashrc_enabled and self._container_bashrc_path:
             quoted = self._sh_quote(self._container_bashrc_path)
-            command = f'if [ -f {quoted} ]; then source {quoted}; fi; {command}'
+            bashrc_prefix = f'if [ -f {quoted} ]; then source {quoted}; fi; '
         return (
             'export PYTHONUNBUFFERED=1 PYTHONIOENCODING=UTF-8; '
+            f'{bashrc_prefix}'
             'if command -v stdbuf >/dev/null 2>&1; then '
             f'stdbuf -oL -eL {command}; '
             'else '

--- a/mobipick_gui/main_window.py
+++ b/mobipick_gui/main_window.py
@@ -2089,11 +2089,7 @@ class MainWindow(QMainWindow):
             exec_id = uuid.uuid4().hex
             container_name = f"{self._terminal_container_prefix}-{exec_id[:10]}"
 
-            terminal_script = self._container_bashrc_snippet()
-            env_dump = self._build_env_dump_script()
-            if env_dump:
-                terminal_script += env_dump
-            terminal_script += 'exec bash -i'
+            terminal_script = self._container_bashrc_snippet() + 'bash -i'
 
             command_parts = [
                 'docker', 'compose', 'run', '--rm', '--name', container_name,
@@ -2245,10 +2241,16 @@ class MainWindow(QMainWindow):
         tab.container_name = container_name
         tab.exec_id = exec_id
         quoted = self._sh_quote(container_name)
+        env_dump = self._build_env_dump_script()
+        env_exec = ''
+        if env_dump:
+            env_script = self._container_bashrc_snippet() + env_dump
+            env_exec = f'docker exec {quoted} bash -lc {self._sh_quote(env_script)}; '
         script = (
             f'until docker container inspect {quoted} >/dev/null 2>&1; do '
             'sleep 0.2; '
             'done; '
+            f'{env_exec}'
             f'docker logs -f --tail 0 {quoted}'
         )
         tab.start_program('bash', ['-lc', script])

--- a/mobipick_gui/main_window.py
+++ b/mobipick_gui/main_window.py
@@ -729,28 +729,6 @@ class MainWindow(QMainWindow):
         tab = self._prepare_tab_for_origin('log', 'gui')
         tab.output.enqueue(True, '<br>')
 
-    def _log_environment_block(self, tab_key: str, env: QProcessEnvironment | None):
-        if not self._log_environment_enabled or env is None:
-            return
-        try:
-            keys = sorted(str(env_key) for env_key in env.keys())
-        except Exception:
-            return
-
-        lines = ['-------- ENV --------']
-        for env_key in keys:
-            value = env.value(env_key)
-            lines.append(f'{env_key}={value}')
-        lines.append('------------ END ENV ---------')
-
-        for line in lines:
-            escaped = html.escape(line)
-            self._append_gui_html(tab_key, escaped, color=self._env_log_color)
-            self._console_log(3, line)
-
-        self._append_gui_html(tab_key, '&nbsp;', color=self._env_log_color)
-        self._append_gui_html(tab_key, '&nbsp;', color=self._env_log_color)
-
     def _log_event(self, details: str):
         ts = datetime.now().strftime('%H:%M:%S')
         line = f'[{ts}] event: {details}'
@@ -1892,10 +1870,44 @@ class MainWindow(QMainWindow):
         return False
 
     # ---------- Buffering control helper ----------
+    def _env_color_rgb(self) -> tuple[int, int, int]:
+        color = (self._env_log_color or '').strip()
+        if color.startswith('#'):
+            color = color[1:]
+        match = re.fullmatch(r'(?i)[0-9a-f]{6}', color)
+        if match:
+            hex_value = match.group(0)
+            return tuple(int(hex_value[i : i + 2], 16) for i in (0, 2, 4))
+        match = re.fullmatch(r'(?i)[0-9a-f]{3}', color)
+        if match:
+            hex_value = match.group(0)
+            return tuple(int(ch * 2, 16) for ch in hex_value)
+        return (210, 180, 140)
+
+    def _build_env_dump_script(self) -> str:
+        if not self._log_environment_enabled:
+            return ''
+        r, g, b = self._env_color_rgb()
+        color_seq = f'\033[38;2;{r};{g};{b}m'
+        reset_seq = '\033[0m'
+        return (
+            f'printf "{color_seq}-------- ENV --------{reset_seq}\\n"; '
+            'env | sort | while IFS= read -r line; do '
+            f'printf "{color_seq}%s{reset_seq}\\n" "$line"; '
+            'done; '
+            f'printf "{color_seq}------------ END ENV ---------{reset_seq}\\n"; '
+            'printf "\\n"; '
+            'printf "\\n"; '
+        )
+
     def _wrap_line_buffered(self, inner: str) -> str:
         # ensure unbuffered python, utf8, and force line buffered stdout and stderr when available
         # no TTY required
+        env_dump = self._build_env_dump_script()
         command = inner
+        if env_dump:
+            script = f'{env_dump}{inner}'
+            command = f"bash -lc {self._sh_quote(script)}"
         bashrc_prefix = ''
         if self._container_bashrc_enabled and self._container_bashrc_path:
             quoted = self._sh_quote(self._container_bashrc_path)

--- a/mobipick_gui/main_window.py
+++ b/mobipick_gui/main_window.py
@@ -1900,6 +1900,12 @@ class MainWindow(QMainWindow):
             'printf "\\n"; '
         )
 
+    def _container_bashrc_snippet(self) -> str:
+        if not (self._container_bashrc_enabled and self._container_bashrc_path):
+            return ''
+        quoted = self._sh_quote(self._container_bashrc_path)
+        return f'if [ -f {quoted} ]; then source {quoted}; fi; '
+
     def _wrap_line_buffered(self, inner: str) -> str:
         # ensure unbuffered python, utf8, and force line buffered stdout and stderr when available
         # no TTY required
@@ -1908,10 +1914,7 @@ class MainWindow(QMainWindow):
         if env_dump:
             script = f'{env_dump}{inner}'
             command = f"bash -lc {self._sh_quote(script)}"
-        bashrc_prefix = ''
-        if self._container_bashrc_enabled and self._container_bashrc_path:
-            quoted = self._sh_quote(self._container_bashrc_path)
-            bashrc_prefix = f'if [ -f {quoted} ]; then source {quoted}; fi; '
+        bashrc_prefix = self._container_bashrc_snippet()
         return (
             'export PYTHONUNBUFFERED=1 PYTHONIOENCODING=UTF-8; '
             f'{bashrc_prefix}'
@@ -2086,13 +2089,19 @@ class MainWindow(QMainWindow):
             exec_id = uuid.uuid4().hex
             container_name = f"{self._terminal_container_prefix}-{exec_id[:10]}"
 
+            terminal_script = self._container_bashrc_snippet()
+            env_dump = self._build_env_dump_script()
+            if env_dump:
+                terminal_script += env_dump
+            terminal_script += 'exec bash -i'
+
             command_parts = [
                 'docker', 'compose', 'run', '--rm', '--name', container_name,
                 '--label', f'mobipick.exec={exec_id}',
                 '--label', 'mobipick.role=terminal',
                 '--label', 'mobipick.tab=terminal',
                 *self._compose_env_args(),
-                'mobipick_cmd', 'bash'
+                'mobipick_cmd', 'bash', '-lc', terminal_script
             ]
             command_str = self._fmt_args(command_parts)
             launcher = self._build_terminal_launcher(command_str)

--- a/mobipick_gui/main_window.py
+++ b/mobipick_gui/main_window.py
@@ -107,6 +107,7 @@ class MainWindow(QMainWindow):
         self._container_bashrc_path = path_value.strip() if isinstance(path_value, str) else ''
         enable_value = self._container_bashrc_cfg.get('enable', True)
         self._container_bashrc_enabled = bool(enable_value) and bool(self._container_bashrc_path)
+        self._log_environment_enabled = bool(process_cfg.get('log_environment', False))
         self._docker_cp_config = load_docker_cp_config()
         self._synced_container_refs: set[str] = set()
         self._toggle_states: dict[str, str] = {}
@@ -728,27 +729,27 @@ class MainWindow(QMainWindow):
         tab = self._prepare_tab_for_origin('log', 'gui')
         tab.output.enqueue(True, '<br>')
 
-    def _log_environment_block(self, env: QProcessEnvironment | None):
-        if env is None:
+    def _log_environment_block(self, tab_key: str, env: QProcessEnvironment | None):
+        if not self._log_environment_enabled or env is None:
             return
         try:
-            keys = sorted(str(key) for key in env.keys())
+            keys = sorted(str(env_key) for env_key in env.keys())
         except Exception:
             return
 
         lines = ['-------- ENV --------']
-        for key in keys:
-            value = env.value(key)
-            lines.append(f'{key}={value}')
+        for env_key in keys:
+            value = env.value(env_key)
+            lines.append(f'{env_key}={value}')
         lines.append('------------ END ENV ---------')
 
         for line in lines:
             escaped = html.escape(line)
-            self._append_gui_html('log', escaped, color=self._env_log_color)
+            self._append_gui_html(tab_key, escaped, color=self._env_log_color)
             self._console_log(3, line)
 
-        self._append_log_blank_line()
-        self._append_log_blank_line()
+        self._append_gui_html(tab_key, '&nbsp;', color=self._env_log_color)
+        self._append_gui_html(tab_key, '&nbsp;', color=self._env_log_color)
 
     def _log_event(self, details: str):
         ts = datetime.now().strftime('%H:%M:%S')

--- a/mobipick_gui/main_window.py
+++ b/mobipick_gui/main_window.py
@@ -113,6 +113,7 @@ class MainWindow(QMainWindow):
         self._last_log_origin: dict[str, str] = {}
         self._gui_log_color = str(CONFIG['log'].get('gui_log_color', '#ff00ff'))
         self._command_log_color = str(CONFIG['log'].get('command_log_color', '#4da3ff'))
+        self._env_log_color = str(CONFIG['log'].get('env_log_color', '#d2b48c'))
 
         # sim state
         self._sim_container_name = 'mobipick-run'
@@ -720,6 +721,34 @@ class MainWindow(QMainWindow):
         line = f'[{ts}] $ {fmt}'
         self._append_gui_html('log', html.escape(line), color=self._command_log_color)
         self._console_log(3, line)
+
+    def _append_log_blank_line(self):
+        if 'log' not in self.tasks:
+            return
+        tab = self._prepare_tab_for_origin('log', 'gui')
+        tab.output.enqueue(True, '<br>')
+
+    def _log_environment_block(self, env: QProcessEnvironment | None):
+        if env is None:
+            return
+        try:
+            keys = sorted(str(key) for key in env.keys())
+        except Exception:
+            return
+
+        lines = ['-------- ENV --------']
+        for key in keys:
+            value = env.value(key)
+            lines.append(f'{key}={value}')
+        lines.append('------------ END ENV ---------')
+
+        for line in lines:
+            escaped = html.escape(line)
+            self._append_gui_html('log', escaped, color=self._env_log_color)
+            self._console_log(3, line)
+
+        self._append_log_blank_line()
+        self._append_log_blank_line()
 
     def _log_event(self, details: str):
         ts = datetime.now().strftime('%H:%M:%S')

--- a/mobipick_gui/process_tab.py
+++ b/mobipick_gui/process_tab.py
@@ -38,8 +38,7 @@ class ProcessTab:
         self.exec_id: str | None = None
 
     def start_shell(self, bash_cmd: str):
-        env = self._apply_env()
-        self.parent._log_environment_block(self.key, env)
+        self._apply_env()
         self.parent._append_gui_html(
             self.key,
             f'<i>&gt; {html.escape(bash_cmd)}</i>',
@@ -50,8 +49,7 @@ class ProcessTab:
 
     def start_program(self, program: str, args: list[str]):
         cmdline = program + ' ' + ' '.join(args)
-        env = self._apply_env()
-        self.parent._log_environment_block(self.key, env)
+        self._apply_env()
         self.parent._append_gui_html(
             self.key,
             f'<i>&gt; {html.escape(cmdline)}</i>',

--- a/mobipick_gui/process_tab.py
+++ b/mobipick_gui/process_tab.py
@@ -39,7 +39,7 @@ class ProcessTab:
 
     def start_shell(self, bash_cmd: str):
         env = self._apply_env()
-        self.parent._log_environment_block(env)
+        self.parent._log_environment_block(self.key, env)
         self.parent._append_gui_html(
             self.key,
             f'<i>&gt; {html.escape(bash_cmd)}</i>',
@@ -51,7 +51,7 @@ class ProcessTab:
     def start_program(self, program: str, args: list[str]):
         cmdline = program + ' ' + ' '.join(args)
         env = self._apply_env()
-        self.parent._log_environment_block(env)
+        self.parent._log_environment_block(self.key, env)
         self.parent._append_gui_html(
             self.key,
             f'<i>&gt; {html.escape(cmdline)}</i>',

--- a/mobipick_gui/process_tab.py
+++ b/mobipick_gui/process_tab.py
@@ -38,24 +38,26 @@ class ProcessTab:
         self.exec_id: str | None = None
 
     def start_shell(self, bash_cmd: str):
+        env = self._apply_env()
+        self.parent._log_environment_block(env)
         self.parent._append_gui_html(
             self.key,
             f'<i>&gt; {html.escape(bash_cmd)}</i>',
             color=self.parent._command_log_color,
         )
         self.parent._log_cmd(bash_cmd)
-        self._apply_env()
         self.proc.start('bash', ['-lc', bash_cmd])
 
     def start_program(self, program: str, args: list[str]):
         cmdline = program + ' ' + ' '.join(args)
+        env = self._apply_env()
+        self.parent._log_environment_block(env)
         self.parent._append_gui_html(
             self.key,
             f'<i>&gt; {html.escape(cmdline)}</i>',
             color=self.parent._command_log_color,
         )
         self.parent._log_cmd([program] + args)
-        self._apply_env()
         self.proc.start(program, args)
 
     def pid(self) -> int | None:
@@ -109,6 +111,7 @@ class ProcessTab:
     def _apply_env(self):
         env = self.parent._build_process_environment()
         self.proc.setProcessEnvironment(env)
+        return env
 
     def refresh_environment(self):
         if not self.is_running():


### PR DESCRIPTION
## Summary
- add a container_bashrc option to the GUI configuration defaults and example YAML
- source the configured bashrc inside container sessions before running commands when enabled

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ecadbebad08331839ba1a14dc6b086