### PR TITLE
Fix terminal log escape handling

### DIFF
--- a/mobipick_gui/ansi.py
+++ b/mobipick_gui/ansi.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import html
 import re
 
-SGR_RE = re.compile(r'\x1b\[(\d+(?:;\d+)*)m')
+SGR_RE = re.compile(r'\x1b\[((?:\d+;)*\d*)m')
 OSC_SEQ_RE = re.compile(r'\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)')
 CSI_SEQ_RE = re.compile(r'\x1b\[[0-9;?]*[ -/]*[@-~]')
 
@@ -23,7 +23,7 @@ def ansi_to_html(chunk: str) -> str:
     i = 0
     for m in SGR_RE.finditer(text):
         out.append(text[i:m.start()])
-        params = m.group(1)
+        params = m.group(1) or '0'
         if params == '0':
             while span_stack:
                 out.append('</span>')

--- a/mobipick_gui/main_window.py
+++ b/mobipick_gui/main_window.py
@@ -2526,6 +2526,15 @@ class MainWindow(QMainWindow):
 
         sanitized = CSI_SEQ_RE.sub(_keep_sgr, sanitized)
         sanitized = sanitized.replace('\x1b7', '').replace('\x1b8', '')
+        if '\b' in sanitized:
+            out_chars: list[str] = []
+            for ch in sanitized:
+                if ch == '\b':
+                    if out_chars:
+                        out_chars.pop()
+                else:
+                    out_chars.append(ch)
+            sanitized = ''.join(out_chars)
         return sanitized
 
     def _collapse_carriage_returns(self, text: str) -> str:


### PR DESCRIPTION
## Summary
- treat parameterless ANSI SGR sequences as resets when converting terminal output to HTML
- strip backspace control characters before rendering captured terminal text

## Testing
- python -m compileall mobipick_gui

------
https://chatgpt.com/codex/tasks/task_e_68f0e509c2188331a618aa5efa6d1905